### PR TITLE
[preference] 성향테스트 ui 구현 ,안드로이드 패키지명 파이어베이스와 동일하게 변경

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -9,9 +9,9 @@ plugins {
 }
 
 android {
-    namespace = "com.example.travel_muse_app"
+    namespace = "com.travelmuse.travelmuse"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -24,7 +24,7 @@ android {
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.travel_muse_app"
+        applicationId = "com.travelmuse.travelmuse"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" 
+    package="com.travelmuse.travelmuse">
     <application
         android:label="travel_muse_app"
         android:name="${applicationName}"

--- a/android/app/src/main/kotlin/com/example/travel_muse_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/travel_muse_app/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.travel_muse_app
+package com.travelmuse.travelmuse
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/lib/views/preference/preference_test_page.dart
+++ b/lib/views/preference/preference_test_page.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/preference/widgets/option_button.dart';
+import 'package:travel_muse_app/views/preference/widgets/question_card.dart';
+import 'package:travel_muse_app/views/preference/widgets/result_view.dart';
+
+const Color kPrimaryColor = Color(0xFF03A9F4);
+const Color kSecondaryColor = Color(0xFF2979FF);
+const Color kTertiaryColor = Color(0xFFBDBDBD);
+
+class PreferenceTestPage extends StatefulWidget {
+  const PreferenceTestPage({super.key});
+
+  @override
+  State<PreferenceTestPage> createState() => _PreferenceTestPageState();
+}
+
+class _PreferenceTestPageState extends State<PreferenceTestPage> {
+  final List<Map<String, String>> _questions = [
+    {
+      'questionId': 'q1',
+      'question': '어떤 여행지를 선호하시나요?',
+      'type': 'preference',
+      'details': '도시, 자연, 둘다',
+    },
+    {
+      'questionId': 'q2',
+      'question': '여행 스타일은 어떤가요?',
+      'type': 'preference',
+      'details': '계획형, 즉흥형, 둘다',
+    },
+    {
+      'questionId': 'q3',
+      'question': '여행 시 선호하는 교통수단은?',
+      'type': 'preference',
+      'details': '대중교통, 자가용, 도보',
+    },
+    {
+      'questionId': 'q4',
+      'question': '여행 동반자는 누구인가요?',
+      'type': 'preference',
+      'details': '혼자, 친구, 가족',
+    },
+  ];
+
+  int _currentIndex = 0;
+  final List<Map<String, String>> _answers = [];
+
+  Map<String, String> get _currentQuestion => _questions[_currentIndex];
+  List<String> get _currentOptions => _currentQuestion['details']!.split(', ');
+
+  void _onAnswerSelected(String selectedOption) {
+    final answer = {
+      'questionId': _currentQuestion['questionId']!,
+      'selectedOption': selectedOption,
+      'type': _currentQuestion['type']!,
+      'details': _currentQuestion['details']!,
+    };
+
+    final existingIndex = _answers.indexWhere(
+      (element) => element['questionId'] == _currentQuestion['questionId'],
+    );
+
+    if (existingIndex != -1) {
+      _answers[existingIndex] = answer;
+    } else {
+      _answers.add(answer);
+    }
+
+    setState(() {
+      if (_currentIndex < _questions.length - 1) {
+        _currentIndex++;
+      } else {
+        _currentIndex = _questions.length;
+      }
+    });
+  }
+
+  void _onNextPressed() {
+    final hasAnswered = _answers.any(
+      (a) => a['questionId'] == _currentQuestion['questionId'],
+    );
+
+    if (!hasAnswered) return;
+
+    setState(() {
+      if (_currentIndex < _questions.length - 1) {
+        _currentIndex++;
+      } else {
+        _currentIndex = _questions.length;
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isFinished = _currentIndex >= _questions.length;
+
+    return CupertinoPageScaffold(
+      navigationBar: CupertinoNavigationBar(
+        middle: const Text('성향 테스트', style: TextStyle(color: kTertiaryColor)),
+        backgroundColor: kPrimaryColor.withOpacity(0.9),
+      ),
+      child: SafeArea(
+        child:
+            isFinished
+                ? ResultView(
+                  answers: _answers,
+                  onRestart: () {
+                    setState(() {
+                      _currentIndex = 0;
+                      _answers.clear();
+                    });
+                  },
+                )
+                : Column(
+                  children: [
+                    const SizedBox(height: 20),
+                    QuestionCard(question: _currentQuestion['question']!),
+                    const SizedBox(height: 20),
+                    Expanded(
+                      child: ListView.builder(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        itemCount: _currentOptions.length,
+                        itemBuilder: (context, index) {
+                          final option = _currentOptions[index];
+                          final color =
+                              index % 2 == 0 ? kPrimaryColor : kSecondaryColor;
+                          return OptionButton(
+                            text: option,
+                            color: color,
+                            onPressed: () => _onAnswerSelected(option),
+                          );
+                        },
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.all(16.0),
+                      child: CupertinoButton(
+                        color: kSecondaryColor,
+                        borderRadius: BorderRadius.circular(12),
+                        onPressed: _onNextPressed,
+                        child: const Text(
+                          '다음',
+                          style: TextStyle(color: Colors.white),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+      ),
+    );
+  }
+}

--- a/lib/views/preference/widgets/option_button.dart
+++ b/lib/views/preference/widgets/option_button.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class OptionButton extends StatelessWidget {
+  final String text;
+  final Color color;
+  final VoidCallback onPressed;
+
+  const OptionButton({
+    super.key,
+    required this.text,
+    required this.color,
+    required this.onPressed,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: CupertinoButton(
+        color: color,
+        borderRadius: BorderRadius.circular(12),
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        child: Text(text, style: const TextStyle(color: Colors.white)),
+        onPressed: onPressed,
+      ),
+    );
+  }
+}

--- a/lib/views/preference/widgets/question_card.dart
+++ b/lib/views/preference/widgets/question_card.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/cupertino.dart';
+import '../preference_test_page.dart';
+
+class QuestionCard extends StatelessWidget {
+  final String question;
+
+  const QuestionCard({super.key, required this.question});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Text(
+        question,
+        style: const TextStyle(
+          fontSize: 20,
+          fontWeight: FontWeight.w600,
+          color: kPrimaryColor,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/preference/widgets/result_view.dart
+++ b/lib/views/preference/widgets/result_view.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import '../preference_test_page.dart';
+
+class ResultView extends StatelessWidget {
+  final List<Map<String, String>> answers;
+  final VoidCallback onRestart;
+
+  const ResultView({super.key, required this.answers, required this.onRestart});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const SizedBox(height: 40),
+        const Text(
+          '테스트 결과',
+          style: TextStyle(
+            fontSize: 24,
+            fontWeight: FontWeight.bold,
+            color: kPrimaryColor,
+          ),
+        ),
+        const SizedBox(height: 20),
+        Expanded(
+          child: ListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: answers.length,
+            itemBuilder: (context, index) {
+              final answer = answers[index];
+              return Card(
+                color: CupertinoColors.systemGrey6,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                margin: const EdgeInsets.symmetric(vertical: 8),
+                child: ListTile(
+                  title: Text(
+                    'Q${index + 1}: ${answer['questionId']}',
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      color: kPrimaryColor,
+                    ),
+                  ),
+                  subtitle: Text(
+                    '선택: ${answer['selectedOption']}',
+                    style: const TextStyle(color: Colors.black),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: CupertinoButton(
+            color: kPrimaryColor,
+            borderRadius: BorderRadius.circular(12),
+            onPressed: onRestart,
+            child: const Text('처음으로', style: TextStyle(color: Colors.white)),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
### 🚀: 개요
- 성향테스트 ui 구현 ,안드로이드 패키지명 파이어베이스와 동일하게 변경

### 🚀: 작업 내용
- 성향테스트 ui 구현
- 안드로이드 패키지명 파이어베이스와 동일하게 변경

### 📸: 실행 화면
### 📸: 실행 화면
 <img src="https://github.com/user-attachments/assets/20f55baf-521f-40c6-ad11-991a8e0116d8" width="300" height="600"/>
 <img src="https://github.com/user-attachments/assets/694cc247-9f39-436f-96cb-721d635b3248" width="300" height="600"/>
 <img src="https://github.com/user-attachments/assets/e9487d20-0073-48a5-9b27-3e6b263bc4c5" width="300" height="600"/>
 <img src="https://github.com/user-attachments/assets/26efa1cd-818b-4916-a44b-5a3811480061" width="300" height="600"/>
 <img src="https://github.com/user-attachments/assets/da949012-3dc2-481d-ad26-6be74c66c79b" width="300" height="600"/>



### 🚀: 조정 파일
android/app
[build.gradle.kts](https://github.com/jinsung99123/travel_muse_app/commit/7fca777317982ec668f4fa7f520e1e98336d3f4d#diff-852897104c5cf350a945bb63cd9836c04ab5209a74900a1e8938092f6b9d68fb)
src/main
[AndroidManifest.xml](https://github.com/jinsung99123/travel_muse_app/commit/7fca777317982ec668f4fa7f520e1e98336d3f4d#diff-63272c98a6330850888e633b43ba4c9decee6431a115e0d2731564838eaa1d1d)
kotlin/com/example/travel_muse_app
[MainActivity.kt](https://github.com/jinsung99123/travel_muse_app/commit/7fca777317982ec668f4fa7f520e1e98336d3f4d#diff-1efe93f3403a74c3bbc8a600bb4424fdbf616e1cb6d547f4d93e97224a76ebfc)

### 개발 결과
- 성향테스트 ui
- 안드로이드 패키지명 파이어베이스와 동일하게 변경

### issue
Fixes #7 
Closes #7 
