### PR TITLE
[MyPage] 마이페이지 위젯 분리 및 UI 구현

### DIFF
--- a/lib/views/my_page/my_page.dart
+++ b/lib/views/my_page/my_page.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/my_page/widgets/my_page_menu.dart';
+import 'package:travel_muse_app/views/my_page/widgets/my_profile_screen.dart';
+
+class MyPage extends StatelessWidget {
+  const MyPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        title: const Text('마이페이지'),
+        centerTitle: true,
+        backgroundColor: Colors.teal,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          children: [
+            MyProfileScreen(),
+            const SizedBox(height: 30),
+            MyPageMenu(),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/my_page/widgets/my_page_menu.dart
+++ b/lib/views/my_page/widgets/my_page_menu.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+class MyPageMenu extends StatelessWidget {
+  const MyPageMenu({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final titles = ['내 여행 계획 보기', '내 여행 성향', '여행 성향 재검사'];
+    final icons = [Icons.flight_takeoff, Icons.explore, Icons.refresh];
+
+    return ListView.builder(
+      shrinkWrap: true,
+      itemCount: titles.length,
+      itemBuilder: (context, index) {
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 15),
+          child: ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              elevation: 3,
+              padding: EdgeInsets.zero,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+              ),
+              backgroundColor: Colors.grey[200],
+            ),
+            onPressed: () {},
+            child: ListTile(
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: 20,
+                vertical: 12,
+              ),
+              leading: Icon(icons[index], size: 28, color: Colors.teal),
+              title: Text(
+                titles[index],
+                style: const TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              trailing: const Icon(Icons.arrow_forward_ios, size: 16),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/views/my_page/widgets/my_profile_screen.dart
+++ b/lib/views/my_page/widgets/my_profile_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+class MyProfileScreen extends StatelessWidget {
+  const MyProfileScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        const CircleAvatar(
+          radius: 35,
+          backgroundImage: AssetImage('assets/profile.png'),
+        ),
+        const SizedBox(width: 15),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: const [
+              Text(
+                '홍길동',
+                style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              ),
+              SizedBox(height: 4),
+              Text('기타 정보', style: TextStyle(fontSize: 14, color: Colors.grey)),
+            ],
+          ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.edit, color: Colors.teal),
+          onPressed: () {},
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
### 🚀: 개요
- [MyPage] 마이페이지 위젯 분리 및 UI 구현

### 🚀: 작업 내용
- 마이페이지 위젯 분리
- UI 구현

### 📸: 실행 화면
### 📸: 실행 화면
<img width="318" alt="스크린샷 2025-05-30 오후 8 56 33" src="https://github.com/user-attachments/assets/0a467249-e2ed-4b2b-9a96-c35a6b822a1f" />


### 🚀: 조정 파일
- my_page.dart
- my_profile_screen.dart
- my_page_menu.dart

### 개발 결과
- 마이페이지 위젯 분리
- 마이페이지 ui 임시 구현
- elevated button 임시 설정

### issue
Closes #1 
