### PR TITLE
[Home] 스플레시 페이지 UI 구현

### DIFF
--- a/lib/views/home/home_page.dart
+++ b/lib/views/home/home_page.dart
@@ -8,7 +8,7 @@ import 'package:travel_muse_app/views/home/widgets/section_title.dart';
 import 'package:travel_muse_app/views/home/widgets/travel_register_button.dart';
 
 class HomePage extends StatefulWidget {
-  const HomePage({Key? key}) : super(key: key);
+  const HomePage({super.key});
 
   @override
   State<HomePage> createState() => _HomePageState();

--- a/lib/views/splash/splash_page.dart
+++ b/lib/views/splash/splash_page.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/my_page/my_page.dart';
+
+class SplashPage extends StatefulWidget {
+  const SplashPage({super.key});
+
+  @override
+  State<SplashPage> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashPage> {
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      backgroundColor: Colors.white,
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            FlutterLogo(size: 100),
+            SizedBox(height: 20),
+            Text('로딩 중', style: TextStyle(fontSize: 18)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/splash/splash_page.dart
+++ b/lib/views/splash/splash_page.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/home/home_page.dart';
 import 'package:travel_muse_app/views/my_page/my_page.dart';
 
 class SplashPage extends StatefulWidget {
@@ -17,7 +18,7 @@ class _SplashScreenState extends State<SplashPage> {
     Timer(const Duration(seconds: 2), () {
       Navigator.pushReplacement(
         context,
-        MaterialPageRoute(builder: (context) => const MyPage()),
+        MaterialPageRoute(builder: (context) => const HomePage()),
       );
     });
   }

--- a/lib/views/splash/splash_page.dart
+++ b/lib/views/splash/splash_page.dart
@@ -13,6 +13,13 @@ class _SplashScreenState extends State<SplashPage> {
   @override
   void initState() {
     super.initState();
+
+    Timer(const Duration(seconds: 2), () {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(builder: (context) => const MyPage()),
+      );
+    });
   }
 
   @override


### PR DESCRIPTION
### 🚀: 개요
- [Home] 스플레시 페이지 UI 구현

### 🚀: 작업 내용
- 스플레시 페이지 UI 구현
- 임시 네비게이터 설정

### 📸: 실행 화면
### 📸: 실행 화면
<img width="321" alt="스크린샷 2025-06-02 오전 10 12 36" src="https://github.com/user-attachments/assets/c31f378b-1b19-4c86-a856-4d80e0ea6cee" />


### 🚀: 조정 파일
- splash_page.dart
- home_page.dart

### 개발 결과
- 스플레시 페이지 UI 구현
- 임시 네비게이터 설정


### issue
Closes #17 
