### PR TITLE
[plan] 장소 검색 및 리스트 페이지 ui

### DIFF
--- a/lib/views/plan/place_search_page.dart
+++ b/lib/views/plan/place_search_page.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/plan/widgets/search_bar.dart';
+import 'package:travel_muse_app/views/plan/widgets/search_result_list.dart';
+
+class PlaceSearchPage extends StatefulWidget {
+  const PlaceSearchPage({super.key});
+
+  @override
+  State<PlaceSearchPage> createState() => _PlaceSearchPageState();
+}
+
+class _PlaceSearchPageState extends State<PlaceSearchPage> {
+  final TextEditingController _searchController = TextEditingController();
+  List<Map<String, String>> _searchResults = [];
+
+  final List<Map<String, String>> _places = [
+    {
+      'title': '서울 타워',
+      'subtitle': '서울 야경 명소',
+      'image':
+          'https://cdn.pixabay.com/photo/2017/06/24/04/37/cloud-2436676_1280.jpg',
+    },
+    {
+      'title': '서울 경복궁',
+      'subtitle': '조선의 중심 궁궐',
+      'image':
+          'https://cdn.pixabay.com/photo/2017/06/24/04/37/cloud-2436676_1280.jpg',
+    },
+    {
+      'title': '제주도',
+      'subtitle': '자연과 함께하는 힐링 여행',
+      'image':
+          'https://cdn.pixabay.com/photo/2017/06/24/04/37/cloud-2436676_1280.jpg',
+    },
+    {
+      'title': '해운대',
+      'subtitle': '부산의 대표 바닷가',
+      'image':
+          'https://cdn.pixabay.com/photo/2017/06/24/04/37/cloud-2436676_1280.jpg',
+    },
+  ];
+
+  //로직 구현시 viewmodel로 분리
+  void _performSearch(String query) {
+    final results =
+        _places
+            .where((place) => place['title']!.contains(query.trim()))
+            .toList();
+
+    setState(() {
+      _searchResults = results;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      resizeToAvoidBottomInset: true,
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: Column(
+          children: [
+            //검색창 위젯
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: SearchBarWithBackButton(
+                controller: _searchController,
+                onBack: () => Navigator.pop(context),
+                onSearch: () => _performSearch(_searchController.text),
+                onSubmitted: _performSearch,
+              ),
+            ),
+            //결과 리스트
+            Expanded(
+              child:
+                  _searchResults.isEmpty
+                      ? const Center(child: Text('검색 결과가 없습니다.'))
+                      : SearchResultList(places: _searchResults),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/plan/widgets/plan_place_card.dart
+++ b/lib/views/plan/widgets/plan_place_card.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+class PlanPlaceCard extends StatelessWidget {
+  const PlanPlaceCard({super.key, required this.place});
+  final Map<String, String> place;
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Container(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          color: Colors.white,
+          boxShadow: [
+            BoxShadow(
+              color: Color.fromRGBO(158, 158, 158, 0.1),
+              blurRadius: 8,
+              offset: const Offset(0, 4),
+            ),
+          ],
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(16),
+          child: Row(
+            children: [
+              Image.network(
+                place['image']!,
+                width: 100,
+                height: 100,
+                fit: BoxFit.cover,
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      place['title']!,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      place['subtitle']!,
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: Colors.grey[700],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/plan/widgets/search_bar.dart
+++ b/lib/views/plan/widgets/search_bar.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class SearchBarWithBackButton extends StatelessWidget {
+  const SearchBarWithBackButton({
+    super.key,
+    required this.controller,
+    required this.onBack,
+    required this.onSearch,
+    required this.onSubmitted,
+  });
+  final TextEditingController controller;
+  final VoidCallback onBack;
+  final VoidCallback onSearch;
+  final Function(String) onSubmitted;
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      decoration: BoxDecoration(
+        color: Colors.grey[200],
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Row(
+        children: [
+          IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: onBack,
+          ),
+          Expanded(
+            child: TextField(
+              controller: controller,
+              decoration: const InputDecoration(
+                hintText: '장소 검색',
+                border: InputBorder.none,
+              ),
+              onSubmitted: onSubmitted,
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.search),
+            onPressed: onSearch,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/plan/widgets/search_result_list.dart
+++ b/lib/views/plan/widgets/search_result_list.dart
@@ -1,0 +1,18 @@
+
+import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/plan/widgets/plan_place_card.dart';
+
+class SearchResultList extends StatelessWidget {
+  const SearchResultList({super.key, required this.places});
+  final List<Map<String, String>> places;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: places.length,
+      itemBuilder: (context, index) {
+        return PlanPlaceCard(place: places[index]);
+      },
+    );
+  }
+}


### PR DESCRIPTION
### 🚀: 개요
-장소 검색 및 리스트 페이지 UI 레이아웃 구현

### 🚀: 작업 내용
-장소 검색 및 리스트 페이지 UI 레이아웃 구현
- 위젯 분리

### 📸: 실행 화면
![Simulator Screenshot - iPhone 15 Pro Max - 2025-06-02 at 12 08 11](https://github.com/user-attachments/assets/c9d18e35-86f5-453f-ba42-81795d0381b0)

### 🚀: 조정 파일
- search_result_list.dart
- search_bar.dart
- place_search_page.dart
- plan_place_card.dart

### 개발 결과
- 장소 검색 및 리스트 페이지  생성 완료
- 위젯 분리 및 컴포넌트 완료

### issue
Closes #11 
