### PR TITLE
[Plan] 지역 선택 페이지 UI 구현

### DIFF
--- a/lib/views/plan/location_setting/widgets/selectable_box.dart
+++ b/lib/views/plan/location_setting/widgets/selectable_box.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class SelectableBox extends StatelessWidget {
+  const SelectableBox({
+    required this.text,
+    required this.isSelected,
+    required this.onTap,
+    required this.width,
+    this.height = 80,
+    super.key,
+  });
+  final String text;
+  final bool isSelected;
+  final VoidCallback onTap;
+  final double width;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: width,
+        height: height,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: isSelected ? Colors.blue : Colors.transparent,
+          border: Border.all(
+            color: isSelected ? Colors.blue : Colors.grey.shade400,
+          ),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Text(
+          text,
+          style: TextStyle(
+            fontSize: 18,
+            color: isSelected ? Colors.white : Colors.black,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/plan/location_setting/widgets/selectable_box_list.dart
+++ b/lib/views/plan/location_setting/widgets/selectable_box_list.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/plan/location_setting/%08widgets/selectable_box.dart';
+
+class SelectableBoxList extends StatelessWidget {
+  const SelectableBoxList({
+    required this.items,
+    required this.selectedIndices,
+    required this.onTap,
+    super.key,
+  });
+  final List<String> items;
+  final Set<int> selectedIndices;
+  final Function(int index) onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    double boxWidth = (MediaQuery.of(context).size.width - 48) / 3;
+
+    return Expanded(
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 10,
+        children: List.generate(items.length, (index) {
+          bool isSelected = selectedIndices.contains(index);
+
+          return SelectableBox(
+            text: items[index],
+            width: boxWidth,
+            isSelected: isSelected,
+            onTap: () => onTap(index),
+          );
+        }),
+      ),
+    );
+  }
+}

--- a/lib/views/plan/location_setting/district_setting_page.dart
+++ b/lib/views/plan/location_setting/district_setting_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/plan/location_setting/%08widgets/selectable_box_list.dart';
 
 class DistrictSettingPage extends StatefulWidget {
   const DistrictSettingPage({super.key});
@@ -11,10 +12,18 @@ class _DistrictSettingPageState extends State<DistrictSettingPage> {
   final List<String> items = List.generate(9, (index) => '마포');
   final Set<int> selectedIndices = {};
 
+  void onItemTap(int index) {
+    setState(() {
+      if (selectedIndices.contains(index)) {
+        selectedIndices.remove(index);
+      } else {
+        selectedIndices.add(index);
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
-    double boxWidth = (MediaQuery.of(context).size.width - 48) / 3;
-
     return Scaffold(
       appBar: AppBar(title: Text('여행할 지역을 선택해주세요')),
       body: SafeArea(
@@ -22,46 +31,10 @@ class _DistrictSettingPageState extends State<DistrictSettingPage> {
           padding: const EdgeInsets.all(16.0),
           child: Column(
             children: [
-              Expanded(
-                child: Wrap(
-                  spacing: 8,
-                  runSpacing: 10,
-                  children: List.generate(items.length, (index) {
-                    bool isSelected = selectedIndices.contains(index);
-
-                    return GestureDetector(
-                      onTap: () {
-                        setState(() {
-                          if (isSelected) {
-                            selectedIndices.remove(index);
-                          } else {
-                            selectedIndices.add(index);
-                          }
-                        });
-                      },
-                      child: Container(
-                        width: boxWidth,
-                        height: 80,
-                        alignment: Alignment.center,
-                        decoration: BoxDecoration(
-                          color: isSelected ? Colors.blue : Colors.transparent,
-                          border: Border.all(
-                            color:
-                                isSelected ? Colors.blue : Colors.grey.shade400,
-                          ),
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Text(
-                          items[index],
-                          style: TextStyle(
-                            fontSize: 18,
-                            color: isSelected ? Colors.white : Colors.black,
-                          ),
-                        ),
-                      ),
-                    );
-                  }),
-                ),
+              SelectableBoxList(
+                items: items,
+                selectedIndices: selectedIndices,
+                onTap: onItemTap,
               ),
 
               SizedBox(height: 24),
@@ -78,7 +51,7 @@ class _DistrictSettingPageState extends State<DistrictSettingPage> {
                     Navigator.pop(context);
                   },
                   child: Text(
-                    '다음 버튼',
+                    '다음',
                     style: TextStyle(fontSize: 16, color: Colors.white),
                   ),
                 ),

--- a/lib/views/plan/location_setting/district_setting_page.dart
+++ b/lib/views/plan/location_setting/district_setting_page.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+
+class DistrictSettingPage extends StatefulWidget {
+  const DistrictSettingPage({super.key});
+
+  @override
+  _DistrictSettingPageState createState() => _DistrictSettingPageState();
+}
+
+class _DistrictSettingPageState extends State<DistrictSettingPage> {
+  final List<String> items = List.generate(9, (index) => '마포');
+  final Set<int> selectedIndices = {};
+
+  @override
+  Widget build(BuildContext context) {
+    double boxWidth = (MediaQuery.of(context).size.width - 48) / 3;
+
+    return Scaffold(
+      appBar: AppBar(title: Text('여행할 지역을 선택해주세요')),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            children: [
+              Expanded(
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 10,
+                  children: List.generate(items.length, (index) {
+                    bool isSelected = selectedIndices.contains(index);
+
+                    return GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          if (isSelected) {
+                            selectedIndices.remove(index);
+                          } else {
+                            selectedIndices.add(index);
+                          }
+                        });
+                      },
+                      child: Container(
+                        width: boxWidth,
+                        height: 80,
+                        alignment: Alignment.center,
+                        decoration: BoxDecoration(
+                          color: isSelected ? Colors.blue : Colors.transparent,
+                          border: Border.all(
+                            color:
+                                isSelected ? Colors.blue : Colors.grey.shade400,
+                          ),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Text(
+                          items[index],
+                          style: TextStyle(
+                            fontSize: 18,
+                            color: isSelected ? Colors.white : Colors.black,
+                          ),
+                        ),
+                      ),
+                    );
+                  }),
+                ),
+              ),
+
+              SizedBox(height: 24),
+
+              SizedBox(
+                width: double.infinity,
+                height: 50,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.blue,
+                    padding: EdgeInsets.symmetric(vertical: 0),
+                  ),
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                  child: Text(
+                    '다음 버튼',
+                    style: TextStyle(fontSize: 16, color: Colors.white),
+                  ),
+                ),
+              ),
+
+              SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/plan/location_setting/province_setting_page.dart
+++ b/lib/views/plan/location_setting/province_setting_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
-import 'district_setting_page.dart';
+import 'package:travel_muse_app/views/plan/location_setting/%08widgets/selectable_box_list.dart';
+import 'package:travel_muse_app/views/plan/location_setting/district_setting_page.dart';
 
 class ProvinceSettingPage extends StatefulWidget {
   const ProvinceSettingPage({super.key});
@@ -10,12 +11,20 @@ class ProvinceSettingPage extends StatefulWidget {
 
 class _ProvinceSettingPageState extends State<ProvinceSettingPage> {
   final List<String> items = List.generate(9, (index) => '서울');
-  final Set<int> selectedIndices = {}; // 선택된 아이템 인덱스 저장
+  final Set<int> selectedIndices = {};
+
+  void onItemTap(int index) {
+    setState(() {
+      if (selectedIndices.contains(index)) {
+        selectedIndices.remove(index);
+      } else {
+        selectedIndices.add(index);
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
-    double boxWidth = (MediaQuery.of(context).size.width - 48) / 3;
-
     return Scaffold(
       appBar: AppBar(title: Text('여행할 지역을 선택해주세요')),
       body: SafeArea(
@@ -23,46 +32,10 @@ class _ProvinceSettingPageState extends State<ProvinceSettingPage> {
           padding: const EdgeInsets.all(16.0),
           child: Column(
             children: [
-              Expanded(
-                child: Wrap(
-                  spacing: 8,
-                  runSpacing: 10,
-                  children: List.generate(items.length, (index) {
-                    bool isSelected = selectedIndices.contains(index);
-
-                    return GestureDetector(
-                      onTap: () {
-                        setState(() {
-                          if (isSelected) {
-                            selectedIndices.remove(index);
-                          } else {
-                            selectedIndices.add(index);
-                          }
-                        });
-                      },
-                      child: Container(
-                        width: boxWidth,
-                        height: 80,
-                        alignment: Alignment.center,
-                        decoration: BoxDecoration(
-                          color: isSelected ? Colors.blue : Colors.transparent,
-                          border: Border.all(
-                            color:
-                                isSelected ? Colors.blue : Colors.grey.shade400,
-                          ),
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Text(
-                          items[index],
-                          style: TextStyle(
-                            fontSize: 18,
-                            color: isSelected ? Colors.white : Colors.black,
-                          ),
-                        ),
-                      ),
-                    );
-                  }),
-                ),
+              SelectableBoxList(
+                items: items,
+                selectedIndices: selectedIndices,
+                onTap: onItemTap,
               ),
 
               SizedBox(height: 24),
@@ -82,7 +55,7 @@ class _ProvinceSettingPageState extends State<ProvinceSettingPage> {
                     );
                   },
                   child: Text(
-                    '다음 버튼',
+                    '다음',
                     style: TextStyle(fontSize: 16, color: Colors.white),
                   ),
                 ),

--- a/lib/views/plan/location_setting/province_setting_page.dart
+++ b/lib/views/plan/location_setting/province_setting_page.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'district_setting_page.dart';
+
+class ProvinceSettingPage extends StatefulWidget {
+  const ProvinceSettingPage({super.key});
+
+  @override
+  _ProvinceSettingPageState createState() => _ProvinceSettingPageState();
+}
+
+class _ProvinceSettingPageState extends State<ProvinceSettingPage> {
+  final List<String> items = List.generate(9, (index) => '서울');
+  final Set<int> selectedIndices = {}; // 선택된 아이템 인덱스 저장
+
+  @override
+  Widget build(BuildContext context) {
+    double boxWidth = (MediaQuery.of(context).size.width - 48) / 3;
+
+    return Scaffold(
+      appBar: AppBar(title: Text('여행할 지역을 선택해주세요')),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            children: [
+              Expanded(
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 10,
+                  children: List.generate(items.length, (index) {
+                    bool isSelected = selectedIndices.contains(index);
+
+                    return GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          if (isSelected) {
+                            selectedIndices.remove(index);
+                          } else {
+                            selectedIndices.add(index);
+                          }
+                        });
+                      },
+                      child: Container(
+                        width: boxWidth,
+                        height: 80,
+                        alignment: Alignment.center,
+                        decoration: BoxDecoration(
+                          color: isSelected ? Colors.blue : Colors.transparent,
+                          border: Border.all(
+                            color:
+                                isSelected ? Colors.blue : Colors.grey.shade400,
+                          ),
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                        child: Text(
+                          items[index],
+                          style: TextStyle(
+                            fontSize: 18,
+                            color: isSelected ? Colors.white : Colors.black,
+                          ),
+                        ),
+                      ),
+                    );
+                  }),
+                ),
+              ),
+
+              SizedBox(height: 24),
+
+              SizedBox(
+                width: double.infinity,
+                height: 50,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Colors.blue,
+                    padding: EdgeInsets.symmetric(vertical: 0),
+                  ),
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(builder: (_) => DistrictSettingPage()),
+                    );
+                  },
+                  child: Text(
+                    '다음 버튼',
+                    style: TextStyle(fontSize: 16, color: Colors.white),
+                  ),
+                ),
+              ),
+
+              SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### 🚀: 개요
- 지역 선택 페이지 UI 구현

### 🚀: 작업 내용
- 지역 선택 페이지 UI 구현
- 위젯 분리
- 상태 관리

### 📸: 실행 화면
### 📸: 실행 화면
<img width="311" alt="스크린샷 2025-06-04 오후 4 03 06" src="https://github.com/user-attachments/assets/c280c6e4-e72e-4797-bf40-2929b7bc5d7d" />


### 🚀: 조정 파일
- province_setting_page.dart
- district_setting_page.dart
- selectable_box_list.dart
- selctable_box.dart

### 개발 결과
- 지역 선택 페이지 UI 구현
- 위젯 분리
- 상태 관리
- 버튼 클릭 on/off 가능


### issue
Closes #31 
