### PR TITLE
[preference] 성향테스트 파이어스토어 연동 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final router = GoRouter(
-      initialLocation: '/',
+      initialLocation: '/preference_test',
       routes: [
         GoRoute(path: '/', builder: (context, state) => const LoginPage()),
         GoRoute(path: '/home', builder: (context, state) => const HomePage()),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,7 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final router = GoRouter(
-      initialLocation: '/preference_test',
+      initialLocation: '/',
       routes: [
         GoRoute(path: '/', builder: (context, state) => const LoginPage()),
         GoRoute(path: '/home', builder: (context, state) => const HomePage()),

--- a/lib/models/preference_test_model.dart
+++ b/lib/models/preference_test_model.dart
@@ -1,0 +1,82 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class PreferenceAnswer {
+  final String questionId;
+  final String selectedOption;
+
+  PreferenceAnswer({required this.questionId, required this.selectedOption});
+
+  Map<String, String> toMap() => {
+    'questionId': questionId,
+    'selectedOption': selectedOption,
+  };
+
+  factory PreferenceAnswer.fromMap(Map<String, dynamic> map) {
+    return PreferenceAnswer(
+      questionId: map['questionId'] ?? '',
+      selectedOption: map['selectedOption'] ?? '',
+    );
+  }
+}
+
+class PreferenceTest {
+  final String testId;
+  final String userId;
+  final List<PreferenceAnswer> answers;
+  final Map<String, String>
+  result; // e.g., {'type': 'a', 'details': '계획형 여행가 ...'}
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  PreferenceTest({
+    required this.testId,
+    required this.userId,
+    required this.answers,
+    required this.result,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  Map<String, dynamic> toMap() => {
+    'testId': testId,
+    'userId': userId,
+    'answers': answers.map((a) => a.toMap()).toList(),
+    'result': result,
+    'createAt': createdAt,
+    'updateAt': updatedAt,
+  };
+
+  ///Firestore에서 가져올 때 사용
+  factory PreferenceTest.fromDoc(String id, Map<String, dynamic> map) {
+    return PreferenceTest(
+      testId: id,
+      userId: map['userId'] ?? '',
+      answers:
+          (map['answers'] as List<dynamic>)
+              .map((e) => PreferenceAnswer.fromMap(e))
+              .toList(),
+      result: Map<String, String>.from(map['result']),
+      createdAt: (map['createAt'] as Timestamp).toDate(),
+      updatedAt: (map['updateAt'] as Timestamp).toDate(),
+    );
+  }
+
+  /// copyWith 메서드
+  PreferenceTest copyWith({
+    String? testId,
+    String? userId,
+    List<PreferenceAnswer>? answers,
+    Map<String, String>? result,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return PreferenceTest(
+      testId: testId ?? this.testId,
+      userId: userId ?? this.userId,
+      answers: answers ?? this.answers,
+      result: result ?? this.result,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+}

--- a/lib/models/preference_test_model.dart
+++ b/lib/models/preference_test_model.dart
@@ -1,15 +1,8 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class PreferenceAnswer {
-  final String questionId;
-  final String selectedOption;
 
   PreferenceAnswer({required this.questionId, required this.selectedOption});
-
-  Map<String, String> toMap() => {
-    'questionId': questionId,
-    'selectedOption': selectedOption,
-  };
 
   factory PreferenceAnswer.fromMap(Map<String, dynamic> map) {
     return PreferenceAnswer(
@@ -17,16 +10,16 @@ class PreferenceAnswer {
       selectedOption: map['selectedOption'] ?? '',
     );
   }
+  final String questionId;
+  final String selectedOption;
+
+  Map<String, String> toMap() => {
+    'questionId': questionId,
+    'selectedOption': selectedOption,
+  };
 }
 
 class PreferenceTest {
-  final String testId;
-  final String userId;
-  final List<PreferenceAnswer> answers;
-  final Map<String, String>
-  result; // e.g., {'type': 'a', 'details': '계획형 여행가 ...'}
-  final DateTime createdAt;
-  final DateTime updatedAt;
 
   PreferenceTest({
     required this.testId,
@@ -36,15 +29,6 @@ class PreferenceTest {
     required this.createdAt,
     required this.updatedAt,
   });
-
-  Map<String, dynamic> toMap() => {
-    'testId': testId,
-    'userId': userId,
-    'answers': answers.map((a) => a.toMap()).toList(),
-    'result': result,
-    'createAt': createdAt,
-    'updateAt': updatedAt,
-  };
 
   ///Firestore에서 가져올 때 사용
   factory PreferenceTest.fromDoc(String id, Map<String, dynamic> map) {
@@ -60,6 +44,22 @@ class PreferenceTest {
       updatedAt: (map['updateAt'] as Timestamp).toDate(),
     );
   }
+  final String testId;
+  final String userId;
+  final List<PreferenceAnswer> answers;
+  final Map<String, String>
+  result; // e.g., {'type': 'a', 'details': '계획형 여행가 ...'}
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  Map<String, dynamic> toMap() => {
+    'testId': testId,
+    'userId': userId,
+    'answers': answers.map((a) => a.toMap()).toList(),
+    'result': result,
+    'createAt': createdAt,
+    'updateAt': updatedAt,
+  };
 
   /// copyWith 메서드
   PreferenceTest copyWith({

--- a/lib/providers/preference_test_provider.dart
+++ b/lib/providers/preference_test_provider.dart
@@ -12,3 +12,7 @@ final preferenceTestStreamProvider =
       final service = PreferenceTestService();
       return service.watchTest(testId);
     });
+final preferenceTestViewModelProvider =
+    NotifierProvider<PreferenceTestViewModel, AsyncValue<PreferenceTest?>>(
+      () => PreferenceTestViewModel(),
+    );

--- a/lib/providers/preference_test_provider.dart
+++ b/lib/providers/preference_test_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travel_muse_app/models/preference_test_model.dart';
+import 'package:travel_muse_app/services/preference_test_service.dart';
+import 'package:travel_muse_app/viewmodels/preference_test_view_model.dart';
+
+final preferenceTestProvider =
+    NotifierProvider<PreferenceTestViewModel, AsyncValue<PreferenceTest?>>(
+      () => PreferenceTestViewModel(),
+    );
+final preferenceTestStreamProvider =
+    StreamProvider.family<PreferenceTest, String>((ref, testId) {
+      final service = PreferenceTestService();
+      return service.watchTest(testId);
+    });

--- a/lib/providers/preference_test_provider.dart
+++ b/lib/providers/preference_test_provider.dart
@@ -1,6 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/models/preference_test_model.dart';
-import 'package:travel_muse_app/services/preference_test_service.dart';
+import 'package:travel_muse_app/repositories/preference_test_repository.dart';
 import 'package:travel_muse_app/viewmodels/preference_test_view_model.dart';
 
 final preferenceTestProvider =
@@ -9,8 +9,8 @@ final preferenceTestProvider =
     );
 final preferenceTestStreamProvider =
     StreamProvider.family<PreferenceTest, String>((ref, testId) {
-      final service = PreferenceTestService();
-      return service.watchTest(testId);
+      final repository = PreferenceTestRepository();
+      return repository.watchTest(testId);
     });
 final preferenceTestViewModelProvider =
     NotifierProvider<PreferenceTestViewModel, AsyncValue<PreferenceTest?>>(

--- a/lib/repositories/preference_test_repository.dart
+++ b/lib/repositories/preference_test_repository.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:travel_muse_app/models/preference_test_model.dart';
 import 'package:travel_muse_app/services/ai_service.dart';
 import 'package:travel_muse_app/services/preference_test_service.dart';
@@ -63,15 +64,42 @@ f: 새로운 것 탐험형 여행가
 
   Future<PreferenceTest> saveOrUpdateTest(PreferenceTest test) async {
     if (test.testId.isEmpty) {
-      final newId = await _service.saveTest(test);
+      final newId = await saveTest(test);
       return test.copyWith(testId: newId);
     } else {
-      await _service.saveOrUpdateTest(test);
+      await saveOrUpdateTest(test);
       return test;
     }
   }
 
   Future<PreferenceTest> loadTest(String testId) async {
-    return await _service.fetchTest(testId);
+    return await fetchTest(testId);
+  }
+
+  final _firestore = FirebaseFirestore.instance;
+  final _collection = 'preference_test';
+
+  /// Firestore에 테스트 저장
+  Future<String> saveTest(PreferenceTest test) async {
+    final docRef = _firestore.collection(_collection).doc();
+    final data = test.copyWith(testId: docRef.id).toMap();
+    await docRef.set(data);
+    return docRef.id;
+  }
+
+  /// Firestore에서 테스트 불러오기 (단건)
+  Future<PreferenceTest> fetchTest(String testId) async {
+    final doc = await _firestore.collection(_collection).doc(testId).get();
+    return PreferenceTest.fromDoc(doc.id, doc.data()!);
+  }
+
+  Stream<PreferenceTest> watchTest(String testId) {
+    return _firestore.collection(_collection).doc(testId).snapshots().map((
+      doc,
+    ) {
+      final data = doc.data();
+      if (data == null) throw Exception('문서가 존재하지 않음');
+      return PreferenceTest.fromDoc(doc.id, data);
+    });
   }
 }

--- a/lib/repositories/preference_test_repository.dart
+++ b/lib/repositories/preference_test_repository.dart
@@ -1,0 +1,77 @@
+import 'package:travel_muse_app/models/preference_test_model.dart';
+import 'package:travel_muse_app/services/ai_service.dart';
+import 'package:travel_muse_app/services/preference_test_service.dart';
+
+class PreferenceTestRepository {
+  final _aiService = AiService();
+  final _service = PreferenceTestService();
+
+  final Map<String, String> _typeDescriptions = {
+    'a': '계획형 여행가: 여행을 철저하게 계획하고 준비하는 성향입니다.',
+    'b': '즉흥형 여행가: 계획보다는 즉흥적으로 여행을 즐깁니다.',
+    'c': '자연친화형 여행가: 자연을 가까이에서 즐기길 원합니다.',
+    'd': '도시탐험형 여행가: 도시의 문화와 랜드마크를 탐험합니다.',
+    'e': '혼합형 여행가: 계획과 즉흥을 조화롭게 섞어 여행을 즐깁니다.',
+    'f': '새로운 것 탐험형 여행가: 새로운 것에 대한 호기심으로 여행합니다.',
+  };
+
+  Future<PreferenceTest> classifyTestOnly(
+    List<Map<String, String>> answersRaw,
+  ) async {
+    final resultSummary = answersRaw
+        .map((a) => '${a['question']} => ${a['selectedOption']}')
+        .join(', ');
+
+    final prompt = '''
+사용자의 여행 성향 테스트 결과:
+$resultSummary
+
+아래 중에서 가장 적합한 하나의 여행가 타입 코드만 골라서 반환해줘.
+반드시 아래 중 하나로만 대답해. 추가 설명은 하지 말고, 코드만 반환해.
+
+a: 계획형 여행가
+b: 즉흥형 여행가
+c: 자연친화형 여행가
+d: 도시탐험형 여행가
+e: 혼합형 여행가
+f: 새로운 것 탐험형 여행가
+''';
+
+    final typeCode = await _aiService.getTypeCodeFromAI(prompt);
+    final description = _typeDescriptions[typeCode] ?? '알 수 없는 유형';
+    final now = DateTime.now();
+
+    final answers =
+        answersRaw
+            .map(
+              (a) => PreferenceAnswer(
+                questionId: a['questionId']!,
+                selectedOption: a['selectedOption']!,
+              ),
+            )
+            .toList();
+
+    return PreferenceTest(
+      testId: '',
+      userId: '',
+      answers: answers,
+      result: {'type': typeCode, 'details': description},
+      createdAt: now,
+      updatedAt: now,
+    );
+  }
+
+  Future<PreferenceTest> saveOrUpdateTest(PreferenceTest test) async {
+    if (test.testId.isEmpty) {
+      final newId = await _service.saveTest(test);
+      return test.copyWith(testId: newId);
+    } else {
+      await _service.saveOrUpdateTest(test);
+      return test;
+    }
+  }
+
+  Future<PreferenceTest> loadTest(String testId) async {
+    return await _service.fetchTest(testId);
+  }
+}

--- a/lib/services/preference_test_service.dart
+++ b/lib/services/preference_test_service.dart
@@ -1,0 +1,36 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:travel_muse_app/models/preference_test_model.dart';
+
+class PreferenceTestService {
+  final _firestore = FirebaseFirestore.instance;
+  final _collection = 'preference_test';
+
+  /// Firestore에 테스트 저장
+  Future<String> saveTest(PreferenceTest test) async {
+    final docRef = _firestore.collection(_collection).doc();
+    final data = test.copyWith(testId: docRef.id).toMap();
+    await docRef.set(data);
+    return docRef.id;
+  }
+
+  /// Firestore에서 테스트 불러오기 (단건)
+  Future<PreferenceTest> fetchTest(String testId) async {
+    final doc = await _firestore.collection(_collection).doc(testId).get();
+    return PreferenceTest.fromDoc(doc.id, doc.data()!);
+  }
+
+  Future<void> saveOrUpdateTest(PreferenceTest test) async {
+    final docRef = _firestore.collection(_collection).doc(test.testId);
+    await docRef.set(test.toMap()); // 이미 존재하면 덮어씀
+  }
+
+  Stream<PreferenceTest> watchTest(String testId) {
+    return _firestore.collection(_collection).doc(testId).snapshots().map((
+      doc,
+    ) {
+      final data = doc.data();
+      if (data == null) throw Exception('문서가 존재하지 않음');
+      return PreferenceTest.fromDoc(doc.id, data);
+    });
+  }
+}

--- a/lib/services/preference_test_service.dart
+++ b/lib/services/preference_test_service.dart
@@ -1,36 +1,4 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:travel_muse_app/models/preference_test_model.dart';
 
-class PreferenceTestService {
-  final _firestore = FirebaseFirestore.instance;
-  final _collection = 'preference_test';
-
-  /// Firestore에 테스트 저장
-  Future<String> saveTest(PreferenceTest test) async {
-    final docRef = _firestore.collection(_collection).doc();
-    final data = test.copyWith(testId: docRef.id).toMap();
-    await docRef.set(data);
-    return docRef.id;
-  }
-
-  /// Firestore에서 테스트 불러오기 (단건)
-  Future<PreferenceTest> fetchTest(String testId) async {
-    final doc = await _firestore.collection(_collection).doc(testId).get();
-    return PreferenceTest.fromDoc(doc.id, doc.data()!);
-  }
-
-  Future<void> saveOrUpdateTest(PreferenceTest test) async {
-    final docRef = _firestore.collection(_collection).doc(test.testId);
-    await docRef.set(test.toMap()); // 이미 존재하면 덮어씀
-  }
-
-  Stream<PreferenceTest> watchTest(String testId) {
-    return _firestore.collection(_collection).doc(testId).snapshots().map((
-      doc,
-    ) {
-      final data = doc.data();
-      if (data == null) throw Exception('문서가 존재하지 않음');
-      return PreferenceTest.fromDoc(doc.id, data);
-    });
-  }
-}
+class PreferenceTestService {}

--- a/lib/viewmodels/preference_test_view_model.dart
+++ b/lib/viewmodels/preference_test_view_model.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/models/preference_test_model.dart';
-import 'package:travel_muse_app/services/ai_service.dart';
-import 'package:travel_muse_app/services/preference_test_service.dart';
+import 'package:travel_muse_app/repositories/preference_test_repository.dart';
 
 final preferenceTestViewModelProvider =
     NotifierProvider<PreferenceTestViewModel, AsyncValue<PreferenceTest?>>(
@@ -9,96 +8,39 @@ final preferenceTestViewModelProvider =
     );
 
 class PreferenceTestViewModel extends Notifier<AsyncValue<PreferenceTest?>> {
-  final _aiService = AiService();
-  final _service = PreferenceTestService();
-
-  final Map<String, String> typeDescriptions = {
-    'a': '계획형 여행가: 여행을 철저하게 계획하고 준비하는 성향입니다.',
-    'b': '즉흥형 여행가: 계획보다는 즉흥적으로 여행을 즐깁니다.',
-    'c': '자연친화형 여행가: 자연을 가까이에서 즐기길 원합니다.',
-    'd': '도시탐험형 여행가: 도시의 문화와 랜드마크를 탐험합니다.',
-    'e': '혼합형 여행가: 계획과 즉흥을 조화롭게 섞어 여행을 즐깁니다.',
-    'f': '새로운 것 탐험형 여행가: 새로운 것에 대한 호기심으로 여행합니다.',
-  };
+  final _repository = PreferenceTestRepository();
 
   @override
   AsyncValue<PreferenceTest?> build() {
     return const AsyncValue.data(null);
   }
 
-  /// AI 분석만 실행
   Future<void> classifyTestOnly(List<Map<String, String>> answersRaw) async {
     state = const AsyncValue.loading();
-
     try {
-      final resultSummary = answersRaw
-          .map((a) => '${a['question']} => ${a['selectedOption']}')
-          .join(', ');
-
-      final prompt = '''
-사용자의 여행 성향 테스트 결과:
-$resultSummary
-
-아래 중에서 가장 적합한 하나의 여행가 타입 코드만 골라서 반환해줘.
-반드시 아래 중 하나로만 대답해. 추가 설명은 하지 말고, 코드만 반환해.
-
-a: 계획형 여행가
-b: 즉흥형 여행가
-c: 자연친화형 여행가
-d: 도시탐험형 여행가
-e: 혼합형 여행가
-f: 새로운 것 탐험형 여행가
-''';
-
-      final typeCode = await _aiService.getTypeCodeFromAI(prompt);
-      final description = typeDescriptions[typeCode] ?? '알 수 없는 유형';
-      final now = DateTime.now();
-
-      final answers =
-          answersRaw
-              .map(
-                (a) => PreferenceAnswer(
-                  questionId: a['questionId']!,
-                  selectedOption: a['selectedOption']!,
-                ),
-              )
-              .toList();
-
-      final test = PreferenceTest(
-        testId: '',
-        userId: '',
-        answers: answers,
-        result: {'type': typeCode, 'details': description},
-        createdAt: now,
-        updatedAt: now,
-      );
-
+      final test = await _repository.classifyTestOnly(answersRaw);
       state = AsyncValue.data(test);
     } catch (e, st) {
       state = AsyncValue.error(e, st);
     }
   }
 
-  /// 저장 실행 (AI 분석 이후 상태 기반으로 Firestore 저장)
   Future<void> saveTestToFirestore() async {
     final current = state.value;
     if (current == null) return;
 
-    if (current.testId.isEmpty) {
-      // 새로 생성
-      final newId = await _service.saveTest(current);
-      state = AsyncValue.data(current.copyWith(testId: newId));
-    } else {
-      // 기존 문서 덮어쓰기
-      await _service.saveOrUpdateTest(current);
+    try {
+      final saved = await _repository.saveOrUpdateTest(current);
+      state = AsyncValue.data(saved);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
     }
   }
 
-  /// 단건 로드
   Future<void> loadTest(String testId) async {
     state = const AsyncValue.loading();
     try {
-      final test = await _service.fetchTest(testId);
+      final test = await _repository.loadTest(testId);
       state = AsyncValue.data(test);
     } catch (e, st) {
       state = AsyncValue.error(e, st);

--- a/lib/views/plan/location_setting/province_setting_page.dart
+++ b/lib/views/plan/location_setting/province_setting_page.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:travel_muse_app/views/plan/location_setting/widgets/selectable_box_list.dart';
 import 'package:travel_muse_app/views/plan/location_setting/district_setting_page.dart';
+import 'package:travel_muse_app/views/plan/location_setting/widgets/selectable_box_list.dart';
 
 class ProvinceSettingPage extends StatefulWidget {
   const ProvinceSettingPage({super.key});

--- a/lib/views/preference/widgets/result_view.dart
+++ b/lib/views/preference/widgets/result_view.dart
@@ -5,143 +5,171 @@ import 'package:go_router/go_router.dart';
 import 'package:travel_muse_app/viewmodels/preference_test_view_model.dart';
 import 'package:travel_muse_app/views/preference/preference_test_page.dart';
 
-class ResultView extends ConsumerWidget {
+class ResultView extends ConsumerStatefulWidget {
   const ResultView({super.key, required this.answers, required this.onRestart});
+
   final List<Map<String, String>> answers;
   final VoidCallback onRestart;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ResultView> createState() => _ResultViewState();
+}
+
+class _ResultViewState extends ConsumerState<ResultView> {
+  bool _hasRequestedAI = false;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    if (!_hasRequestedAI) {
+      _hasRequestedAI = true;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        ref
+            .read(preferenceTestViewModelProvider.notifier)
+            .classifyTestOnly(widget.answers);
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final state = ref.watch(preferenceTestViewModelProvider);
 
-    return state.when(
-      data: (data) {
-        final typeCode = data.$1;
-        final description = data.$2;
+    final result = state.value?.result;
+    final typeCode = result?['type'];
+    final description = result?['details'];
 
-        if (typeCode.isEmpty) {
-          // 처음 진입 시 AI 호출 - 빌드가 끝난 뒤 안전하게 호출
-          Future.microtask(() {
-            ref
-                .read(preferenceTestViewModelProvider.notifier)
-                .classifyPersonality(answers);
-          });
-          return const Center(child: CircularProgressIndicator());
-        }
+    if (state.isLoading || typeCode == null || description == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
 
-        return Column(
-          children: [
-            const SizedBox(height: 40),
-            const Text(
-              '테스트 결과',
-              style: TextStyle(
-                fontSize: 24,
-                fontWeight: FontWeight.bold,
-                color: kPrimaryColor,
+    return Column(
+      children: [
+        const SizedBox(height: 40),
+        const Text(
+          '테스트 결과',
+          style: TextStyle(
+            fontSize: 24,
+            fontWeight: FontWeight.bold,
+            color: kPrimaryColor,
+          ),
+        ),
+        const SizedBox(height: 20),
+        Container(
+          margin: const EdgeInsets.symmetric(horizontal: 16),
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: CupertinoColors.systemGrey6,
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black12,
+                offset: Offset(0, 4),
+                blurRadius: 8,
               ),
-            ),
-            const SizedBox(height: 20),
-            // 유형 결과 박스
-            Container(
-              margin: const EdgeInsets.symmetric(horizontal: 16),
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: CupertinoColors.systemGrey6,
-                borderRadius: BorderRadius.circular(12),
-                boxShadow: [
-                  BoxShadow(
-                    color: Colors.black12,
-                    offset: Offset(0, 4),
-                    blurRadius: 8,
-                  ),
-                ],
+            ],
+          ),
+          child: Column(
+            children: [
+              Text(
+                '당신의 타입: $typeCode',
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  color: kPrimaryColor,
+                ),
               ),
-              child: Column(
-                children: [
-                  Text(
-                    '당신의 타입: $typeCode',
+              const SizedBox(height: 12),
+              Text(
+                description,
+                style: const TextStyle(fontSize: 16, color: Colors.black87),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 20),
+        Expanded(
+          child: ListView.builder(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            itemCount: widget.answers.length,
+            itemBuilder: (context, index) {
+              final answer = widget.answers[index];
+              final question = answer['question'] ?? '질문이 없습니다';
+              final selectedOption = answer['selectedOption'] ?? '선택이 없습니다';
+
+              return Card(
+                elevation: 1,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                margin: const EdgeInsets.symmetric(vertical: 6),
+                child: ListTile(
+                  title: Text(
+                    question,
                     style: const TextStyle(
-                      fontSize: 20,
                       fontWeight: FontWeight.bold,
                       color: kPrimaryColor,
                     ),
                   ),
-                  const SizedBox(height: 12),
-                  Text(
-                    description,
-                    style: const TextStyle(fontSize: 16, color: Colors.black87),
-                    textAlign: TextAlign.center,
+                  subtitle: Text(
+                    '선택: $selectedOption',
+                    style: const TextStyle(color: Colors.black87),
                   ),
-                ],
+                ),
+              );
+            },
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            children: [
+              CupertinoButton(
+                color: kPrimaryColor,
+                borderRadius: BorderRadius.circular(12),
+                onPressed: widget.onRestart,
+                child: const Text(
+                  '처음으로',
+                  style: TextStyle(color: Colors.white),
+                ),
               ),
-            ),
-            const SizedBox(height: 20),
-            // 질문/답변 리스트
-            Expanded(
-              child: ListView.builder(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                itemCount: answers.length,
-                itemBuilder: (context, index) {
-                  final answer = answers[index];
-                  final question = answer['question'] ?? '질문이 없습니다';
-                  final selectedOption = answer['selectedOption'] ?? '선택이 없습니다';
-
-                  return Card(
-                    elevation: 1,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    margin: const EdgeInsets.symmetric(vertical: 6),
-                    child: ListTile(
-                      title: Text(
-                        question,
-                        style: const TextStyle(
-                          fontWeight: FontWeight.bold,
-                          color: kPrimaryColor,
-                        ),
-                      ),
-                      subtitle: Text(
-                        '선택: $selectedOption',
-                        style: const TextStyle(color: Colors.black87),
-                      ),
-                    ),
-                  );
-                },
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Column(
-                children: [
-                  CupertinoButton(
-                    color: kPrimaryColor,
-                    borderRadius: BorderRadius.circular(12),
-                    onPressed: onRestart,
-                    child: const Text(
-                      '처음으로',
-                      style: TextStyle(color: Colors.white),
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                  CupertinoButton(
-                    color: CupertinoColors.activeGreen,
-                    borderRadius: BorderRadius.circular(12),
-                    onPressed: () {
+              const SizedBox(height: 12),
+              CupertinoButton(
+                color: CupertinoColors.activeGreen,
+                borderRadius: BorderRadius.circular(12),
+                onPressed: () async {
+                  try {
+                    await ref
+                        .read(preferenceTestViewModelProvider.notifier)
+                        .saveTestToFirestore();
+                    if (context.mounted) {
                       context.go('/home');
-                    },
-                    child: const Text(
-                      '완료',
-                      style: TextStyle(color: Colors.white),
-                    ),
-                  ),
-                ],
+                    }
+                  } catch (e) {
+                    showCupertinoDialog(
+                      context: context,
+                      builder:
+                          (context) => CupertinoAlertDialog(
+                            title: const Text('저장 오류'),
+                            content: Text('저장 중 문제가 발생했습니다.\n$e'),
+                            actions: [
+                              CupertinoDialogAction(
+                                child: const Text('확인'),
+                                onPressed: () => Navigator.of(context).pop(),
+                              ),
+                            ],
+                          ),
+                    );
+                  }
+                },
+                child: const Text('완료', style: TextStyle(color: Colors.white)),
               ),
-            ),
-          ],
-        );
-      },
-      loading: () => const Center(child: CircularProgressIndicator()),
-      error: (e, _) => Center(child: Text('에러: $e')),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/views/preference/widgets/result_view.dart
+++ b/lib/views/preference/widgets/result_view.dart
@@ -2,7 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:travel_muse_app/viewmodels/preference_test_view_model.dart';
+import 'package:travel_muse_app/providers/preference_test_provider.dart';
 import 'package:travel_muse_app/views/preference/preference_test_page.dart';
 
 class ResultView extends ConsumerStatefulWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -125,10 +125,10 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "8cfe3c900512399ce8d50fcc817e5758ff8615eeb6fa5c846a4cc47bbf6353b6"
+      sha256: "26de145bb9688a90962faec6f838247377b0b0d32cc0abecd9a4e43525fc856c"
       url: "https://pub.dev"
     source: hosted
-    version: "3.13.1"
+    version: "2.32.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: ddd72baa6f727e5b23f32d9af23d7d453d67946f380bd9c21daf474ee0f7326e
+      sha256: "362e52457ed2b7b180964769c1e04d1e0ea0259fdf7025fdfedd019d4ae2bd88"
       url: "https://pub.dev"
     source: hosted
     version: "2.23.0"
@@ -561,10 +561,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "0.5.1"
 sdks:
   dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,11 +35,13 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   cloud_firestore: ^5.6.6
-  firebase_core: ^3.13.1
+  firebase_core: ^2.32.0
   firebase_storage: ^12.4.5
   flutter_lints: ^5.0.0
   flutter_riverpod: ^2.6.1
   intl: ^0.20.2
+  cloud_firestore: ^4.13.5
+  firebase_auth: ^4.20.0
   google_generative_ai: ^0.4.7
   go_router: ^15.1.2
   google_maps_flutter: ^2.12.2


### PR DESCRIPTION
### 🚀: 개요
- 성향테스트 파이어스토어 연동 
- 메인 파이어베이스 초기화 추가 

### 🚀: 작업 내용
- ResultView를 ConsumerWidget → ConsumerStatefulWidget으로 변경하여
  addPostFrameCallback을 통해 AI 분석 로직이 딱 1회만 실행되도록 개선
- Firestore 저장 로직을 saveTestToFirestore()로 분리하여
  완료 버튼을 눌렀을 때만 저장되도록 명확하게 처리
- 기존에는 AI 분석 시 자동 저장되던 구조에서,
  분석 결과는 메모리 상태에만 저장되도록 변경하여 UX 흐름 개선
- 저장 실패 시 CupertinoAlertDialog로 오류 안내


### 📸: 실행 화면
### 📸: 실행 화면


### 🚀: 조정 파일
- preference 폴더
- main

### 개발 결과
- 테스트 완료 후 완료 버튼을 눌러야만 Firestore에 문서 생성됨
- 처음으로 버튼은 단순 상태 리셋만 수행 (Firestore와 무관)
- 저장 실패 시 에러 다이얼로그 노출 확인
-추후 구글로그인 연동시 실제 userid로 추가예정 지금은 더미데이터 
-파이어스토어 개발용으로 규칙변경
### issue
Closes #38 
