### PR TITLE
[MyPage] 여행 일정/성향 목록 페이지 ui 구현

### DIFF
--- a/lib/views/my_page/plan_list_page.dart
+++ b/lib/views/my_page/plan_list_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/views/my_page/widgets/schedule_card.dart';
+import 'package:travel_muse_app/views/plan/schedule/schedule_page.dart';
 
 class PlanListPage extends StatelessWidget {
   const PlanListPage({super.key});
@@ -17,17 +18,25 @@ class PlanListPage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.lightBlue,
-        title: Text('여행 일정 목록'),
+        title: const Text('여행 일정 목록'),
       ),
       body: ListView.builder(
         padding: const EdgeInsets.all(12.0),
         itemCount: schedules.length,
         itemBuilder: (context, index) {
           final schedule = schedules[index];
-          return ScheduleCard(
-            title: schedule['title'] ?? '',
-            date: schedule['date'] ?? '',
-            imageUrl: 'https://picsum.photos/800/400?random=$index',
+          return GestureDetector(
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const SchedulePage()),
+              );
+            },
+            child: ScheduleCard(
+              title: schedule['title'] ?? '',
+              date: schedule['date'] ?? '',
+              imageUrl: 'https://picsum.photos/800/400?random=$index',
+            ),
           );
         },
       ),

--- a/lib/views/my_page/plan_list_page.dart
+++ b/lib/views/my_page/plan_list_page.dart
@@ -1,13 +1,36 @@
 import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/my_page/widgets/schedule_card.dart';
 
 class PlanListPage extends StatelessWidget {
   const PlanListPage({super.key});
 
+  static const List<Map<String, String>> schedules = [
+    {'title': '제주도 여행', 'date': '2025-07-01'},
+    {'title': '강원도 캠핑', 'date': '2025-08-15'},
+    {'title': '서울 투어', 'date': '2025-06-20'},
+    {'title': '부산 바다여행', 'date': '2025-09-05'},
+    {'title': '전주 한옥마을', 'date': '2025-10-12'},
+  ];
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('여행 목록 페이지')),
-      body: Text('여행 목록 페이지'),
+      appBar: AppBar(
+        backgroundColor: Colors.lightBlue,
+        title: Text('여행 일정 목록'),
+      ),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(12.0),
+        itemCount: schedules.length,
+        itemBuilder: (context, index) {
+          final schedule = schedules[index];
+          return ScheduleCard(
+            title: schedule['title'] ?? '',
+            date: schedule['date'] ?? '',
+            imageUrl: 'https://picsum.photos/800/400?random=$index',
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/views/my_page/preference_list_page.dart
+++ b/lib/views/my_page/preference_list_page.dart
@@ -1,13 +1,35 @@
 import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/my_page/widgets/preference_card.dart';
 
 class PreferenceListPage extends StatelessWidget {
   const PreferenceListPage({super.key});
 
+  static const List<Map<String, String>> travelStyles = [
+    {'title': '여행 성향1', 'description': '산, 바다, 숲에서 여유를 즐기는 여행'},
+    {'title': '여행 성향2', 'description': '도심 속 카페, 전시, 쇼핑 탐방'},
+    {'title': '여행 성향3', 'description': '하이킹, 스노우보드, 서핑 등 활동적인 여행'},
+    {'title': '여행 성향4', 'description': '지역 맛집 탐방과 음식 중심의 여행'},
+    {'title': '여행 성향5', 'description': '역사와 문화를 배우는 여행'},
+  ];
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('성향 목록 페이지')),
-      body: Text('성향 목록 페이지'),
+      appBar: AppBar(
+        backgroundColor: Colors.lightBlue,
+        title: const Text('여행 성향 목록'),
+      ),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(12.0),
+        itemCount: travelStyles.length,
+        itemBuilder: (context, index) {
+          final style = travelStyles[index];
+          return PreferenceCard(
+            title: style['title'] ?? '',
+            description: style['description'] ?? '',
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/views/my_page/widgets/preference_card.dart
+++ b/lib/views/my_page/widgets/preference_card.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class PreferenceCard extends StatelessWidget {
+  const PreferenceCard({
+    super.key,
+    required this.title,
+    required this.description,
+  });
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      elevation: 2,
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              description,
+              style: TextStyle(fontSize: 14, color: Colors.grey[700]),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/my_page/widgets/schedule_card.dart
+++ b/lib/views/my_page/widgets/schedule_card.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+class ScheduleCard extends StatelessWidget {
+  const ScheduleCard({
+    super.key,
+    required this.title,
+    required this.date,
+    required this.imageUrl,
+  });
+  final String title;
+  final String date;
+  final String imageUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      elevation: 4,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ClipRRect(
+            borderRadius: const BorderRadius.vertical(top: Radius.circular(12)),
+            child: Image.network(
+              imageUrl,
+              height: 180,
+              width: double.infinity,
+              fit: BoxFit.cover,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Row(
+              children: [
+                Icon(Icons.calendar_today, size: 16, color: Colors.grey[600]),
+                SizedBox(width: 6),
+                Text(
+                  date,
+                  style: TextStyle(fontSize: 14, color: Colors.grey[800]),
+                ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(left: 12, right: 12, bottom: 12),
+            child: Text(
+              title,
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### 🚀: 개요
- [MyPage] 여행 일정/성향 목록 페이지 ui 구현

### 🚀: 작업 내용
- 여행 일정 목록 페이지 ui 구현
- 여행 성향 목록 페이지 ui 구현
- 위젯 분리
- 네비게이션 설정

### 📸: 실행 화면
### 📸: 실행 화면
<img width="318" alt="스크린샷 2025-06-05 오후 8 02 12" src="https://github.com/user-attachments/assets/70706b17-61f6-4222-8e72-0f96bcd319e1" />
<img width="310" alt="스크린샷 2025-06-05 오후 8 28 03" src="https://github.com/user-attachments/assets/4763af85-e2ee-49c1-949f-a5b146869325" />



### 🚀: 조정 파일
- plan_list_page.dart
- preference_list_page.dart
- schedule_card.dart
- preference_card.dart

### 개발 결과
- ex) 로그인 페이지 생성 완료
- ex) 위젯 분리 및 컴포넌트 완료

### issue
Closes #52 

