### PR TITLE
[Plan]장소 선택 후 일정에 추가 및 Firebase 저장 기능 구현

### DIFF
--- a/lib/models/plans.dart
+++ b/lib/models/plans.dart
@@ -1,0 +1,80 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:travel_muse_app/models/preference_test_model.dart';
+
+class Plans {
+  Plans({
+    required this.planId,
+    required this.title,
+    required this.region,
+    required this.startDate,
+    required this.endDate,
+    required this.userId,
+    required this.date,
+    required this.createdByAI,
+    required this.preference,
+  });
+
+  final String planId;
+  final String title;
+  final String region;
+  final DateTime startDate;
+  final DateTime endDate;
+  final String userId;
+  final String date;
+  final bool createdByAI;
+  final PreferenceTest? preference;
+
+  factory Plans.fromJson(String id, Map<String, dynamic> json) {
+  final rawStart = json['startDate'];
+  final rawEnd = json['endDate'];
+
+  // 날짜 파싱 함수
+  DateTime? _parseDate(dynamic value) {
+    if (value is Timestamp) return value.toDate();
+    if (value is String) return DateTime.tryParse(value);
+    return null;
+  }
+
+  final parsedStart = _parseDate(rawStart) ?? DateTime.now();
+  final parsedEnd = _parseDate(rawEnd) ?? DateTime.now();
+
+  final preferenceMap = json['preference'];
+  PreferenceTest? preference;
+
+  if (preferenceMap is Map<String, dynamic> &&
+      preferenceMap['answers'] != null) {
+    try {
+      preference = PreferenceTest.fromDoc('', Map<String, dynamic>.from(preferenceMap));
+    } catch (e) {
+      print('❌ Preference 파싱 실패: $e');
+    }
+  }
+
+  return Plans(
+    planId: json['planId'] ?? id,
+    title: json['title'] ?? '',
+    region: json['region'] ?? '',
+    startDate: parsedStart,
+    endDate: parsedEnd,
+    userId: json['userId'] ?? '',
+    date: json['date'] ?? '',
+    createdByAI: json['createdByAI'] ?? false,
+    preference: preference,
+  );
+}
+
+
+  Map<String, dynamic> toJson() {
+    return {
+      'planId': planId,
+      'title': title,
+      'region': region,
+      'startDate': Timestamp.fromDate(startDate),
+      'endDate': Timestamp.fromDate(endDate),
+      'userId': userId,
+      'date': date,
+      'createdByAI': createdByAI,
+      'preference': preference?.toMap(),
+    };
+  }
+}

--- a/lib/providers/schedule_provider.dart
+++ b/lib/providers/schedule_provider.dart
@@ -1,8 +1,18 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/models/plans.dart';
+import 'package:travel_muse_app/repositories/schedule_repository.dart';
 import 'package:travel_muse_app/viewmodels/schedule_view_model.dart';
 
+/// Repository Provider (의존성 주입)
+final scheduleRepositoryProvider = Provider<ScheduleRepository>(
+  (ref) => ScheduleRepository(),
+);
+
+/// ViewModel Provider
 final scheduleViewModelProvider =
     StateNotifierProvider<ScheduleViewModel, AsyncValue<List<Plans>>>(
-  (ref) => ScheduleViewModel(),
+  (ref) {
+    final repository = ref.read(scheduleRepositoryProvider);
+    return ScheduleViewModel(repository);
+  },
 );

--- a/lib/providers/schedule_provider.dart
+++ b/lib/providers/schedule_provider.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travel_muse_app/models/plans.dart';
+import 'package:travel_muse_app/viewmodels/schedule_view_model.dart';
+
+final scheduleViewModelProvider =
+    StateNotifierProvider<ScheduleViewModel, AsyncValue<List<Plans>>>(
+  (ref) => ScheduleViewModel(),
+);

--- a/lib/repositories/schedule_repository.dart
+++ b/lib/repositories/schedule_repository.dart
@@ -1,0 +1,66 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:travel_muse_app/models/plans.dart';
+
+class ScheduleRepository {
+  ScheduleRepository({FirebaseFirestore? firestore})
+      : _firestore = firestore ?? FirebaseFirestore.instance;
+      
+  final FirebaseFirestore _firestore;
+
+
+  Future<List<Plans>> fetchPlans([String? userId]) async {
+    Query query = _firestore.collection('plans');
+    if (userId != null) {
+      query = query.where('userId', isEqualTo: userId);
+    }
+
+    final snapshot = await query.get();
+    return snapshot.docs
+        .map((doc) => Plans.fromJson(doc.id, doc.data() as Map<String, dynamic>))
+        .toList();
+  }
+
+  Future<void> saveDaySchedules({
+    required String planId,
+    required Map<int, List<Map<String, String>>> daySchedules,
+  }) async {
+    final batch = _firestore.batch();
+
+    daySchedules.forEach((dayIndex, places) {
+      final dayRef = _firestore
+          .collection('plans')
+          .doc(planId)
+          .collection('route')
+          .doc('day_$dayIndex');
+
+      batch.set(dayRef, {
+        'places': places,
+      });
+    });
+
+    await batch.commit();
+  }
+
+  Future<Map<int, List<Map<String, String>>>> fetchRoute(String planId) async {
+    final snapshot = await _firestore
+        .collection('plans')
+        .doc(planId)
+        .collection('route')
+        .get();
+
+    final result = <int, List<Map<String, String>>>{};
+
+    for (var doc in snapshot.docs) {
+      final key = int.tryParse(doc.id.replaceFirst('day_', ''));
+      if (key != null) {
+        final data = doc.data();
+        final places = (data['places'] as List)
+            .map((e) => Map<String, String>.from(e))
+            .toList();
+        result[key] = places;
+      }
+    }
+
+    return result;
+  }
+}

--- a/lib/viewmodels/schedule_view_model.dart
+++ b/lib/viewmodels/schedule_view_model.dart
@@ -7,6 +7,7 @@ class ScheduleViewModel extends StateNotifier<AsyncValue<List<Plans>>> {
     fetchPlans();
   }
 
+//plans 데이터 불러오기
   Future<void> fetchPlans() async {
     try {
       final snapshot = await FirebaseFirestore.instance.collection('plans').get();

--- a/lib/viewmodels/schedule_view_model.dart
+++ b/lib/viewmodels/schedule_view_model.dart
@@ -3,34 +3,40 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/models/plans.dart';
 
 class ScheduleViewModel extends StateNotifier<AsyncValue<List<Plans>>> {
-  ScheduleViewModel() : super(const AsyncLoading()) {
-    fetchPlans(); // 기본 호출
-  }
+  ScheduleViewModel() : super(const AsyncLoading());
 
   final _firestore = FirebaseFirestore.instance;
+  List<Plans> _allPlans = [];
 
-  // plans 불러오기 (userId 선택적으로 임시)
+  /// 선택된 plan 캐싱
+  Plans? selectedPlan;
+
+  /// 사용자 계획 불러오기
   Future<void> fetchPlans([String? userId]) async {
     try {
       Query query = _firestore.collection('plans');
-
       if (userId != null) {
         query = query.where('userId', isEqualTo: userId);
       }
-
       final snapshot = await query.get();
 
       final plans = snapshot.docs
-    .map((doc) => Plans.fromJson(doc.id, doc.data() as Map<String, dynamic>))
-    .toList();
+          .map((doc) => Plans.fromJson(doc.id, doc.data() as Map<String, dynamic>))
+          .toList();
 
+      _allPlans = plans;
       state = AsyncData(plans);
     } catch (e, st) {
       state = AsyncError(e, st);
     }
   }
 
-  // daySchedules 저장
+  /// 현재 plan 설정
+  void setSelectedPlan(String planId) {
+    selectedPlan = _allPlans.firstWhere((p) => p.planId == planId, orElse: () => _allPlans.first);
+  }
+
+  /// daySchedules 저장
   Future<void> saveDaySchedules({
     required String planId,
     required Map<int, List<Map<String, String>>> daySchedules,
@@ -53,28 +59,35 @@ class ScheduleViewModel extends StateNotifier<AsyncValue<List<Plans>>> {
     print('✅ daySchedules 저장 완료');
   }
 
-  //route 불러오기
+  /// route 불러오기
   Future<Map<int, List<Map<String, String>>>> fetchRoute(String planId) async {
-  final snapshot = await _firestore
-      .collection('plans')
-      .doc(planId)
-      .collection('route') // 여기 이름 바뀐거!!
-      .get();
+    final snapshot = await _firestore
+        .collection('plans')
+        .doc(planId)
+        .collection('route')
+        .get();
 
-  final result = <int, List<Map<String, String>>>{};
+    final result = <int, List<Map<String, String>>>{};
 
-  for (var doc in snapshot.docs) {
-    final key = int.tryParse(doc.id.replaceFirst('day_', ''));
-    if (key != null) {
-      final data = doc.data();
-      final places = (data['places'] as List)
-          .map((e) => Map<String, String>.from(e))
-          .toList();
-      result[key] = places;
+    for (var doc in snapshot.docs) {
+      final key = int.tryParse(doc.id.replaceFirst('day_', ''));
+      if (key != null) {
+        final data = doc.data();
+        final places = (data['places'] as List)
+            .map((e) => Map<String, String>.from(e))
+            .toList();
+        result[key] = places;
+      }
     }
+
+    return result;
   }
 
-  return result;
+  Plans? getPlanById(String planId) {
+  try {
+    return _allPlans.firstWhere((p) => p.planId == planId);
+  } catch (e) {
+    return null;
+  }
 }
-
 }

--- a/lib/viewmodels/schedule_view_model.dart
+++ b/lib/viewmodels/schedule_view_model.dart
@@ -4,21 +4,77 @@ import 'package:travel_muse_app/models/plans.dart';
 
 class ScheduleViewModel extends StateNotifier<AsyncValue<List<Plans>>> {
   ScheduleViewModel() : super(const AsyncLoading()) {
-    fetchPlans();
+    fetchPlans(); // 기본 호출
   }
 
-//plans 데이터 불러오기
-  Future<void> fetchPlans() async {
-    try {
-      final snapshot = await FirebaseFirestore.instance.collection('plans').get();
+  final _firestore = FirebaseFirestore.instance;
 
-      final plans = snapshot.docs.map(
-        (doc) => Plans.fromJson(doc.id, doc.data()),
-      ).toList();
+  // plans 불러오기 (userId 선택적으로 임시)
+  Future<void> fetchPlans([String? userId]) async {
+    try {
+      Query query = _firestore.collection('plans');
+
+      if (userId != null) {
+        query = query.where('userId', isEqualTo: userId);
+      }
+
+      final snapshot = await query.get();
+
+      final plans = snapshot.docs
+    .map((doc) => Plans.fromJson(doc.id, doc.data() as Map<String, dynamic>))
+    .toList();
 
       state = AsyncData(plans);
     } catch (e, st) {
       state = AsyncError(e, st);
     }
   }
+
+  // daySchedules 저장
+  Future<void> saveDaySchedules({
+    required String planId,
+    required Map<int, List<Map<String, String>>> daySchedules,
+  }) async {
+    final batch = _firestore.batch();
+
+    daySchedules.forEach((dayIndex, places) {
+      final dayRef = _firestore
+          .collection('plans')
+          .doc(planId)
+          .collection('route')
+          .doc('day_$dayIndex');
+
+      batch.set(dayRef, {
+        'places': places,
+      });
+    });
+
+    await batch.commit();
+    print('✅ daySchedules 저장 완료');
+  }
+
+  //route 불러오기
+  Future<Map<int, List<Map<String, String>>>> fetchRoute(String planId) async {
+  final snapshot = await _firestore
+      .collection('plans')
+      .doc(planId)
+      .collection('route') // 여기 이름 바뀐거!!
+      .get();
+
+  final result = <int, List<Map<String, String>>>{};
+
+  for (var doc in snapshot.docs) {
+    final key = int.tryParse(doc.id.replaceFirst('day_', ''));
+    if (key != null) {
+      final data = doc.data();
+      final places = (data['places'] as List)
+          .map((e) => Map<String, String>.from(e))
+          .toList();
+      result[key] = places;
+    }
+  }
+
+  return result;
+}
+
 }

--- a/lib/viewmodels/schedule_view_model.dart
+++ b/lib/viewmodels/schedule_view_model.dart
@@ -1,0 +1,23 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travel_muse_app/models/plans.dart';
+
+class ScheduleViewModel extends StateNotifier<AsyncValue<List<Plans>>> {
+  ScheduleViewModel() : super(const AsyncLoading()) {
+    fetchPlans();
+  }
+
+  Future<void> fetchPlans() async {
+    try {
+      final snapshot = await FirebaseFirestore.instance.collection('plans').get();
+
+      final plans = snapshot.docs.map(
+        (doc) => Plans.fromJson(doc.id, doc.data()),
+      ).toList();
+
+      state = AsyncData(plans);
+    } catch (e, st) {
+      state = AsyncError(e, st);
+    }
+  }
+}

--- a/lib/viewmodels/search_view_model.dart
+++ b/lib/viewmodels/search_view_model.dart
@@ -19,6 +19,8 @@ class SearchViewModel extends StateNotifier<List<Map<String, String>>> {
         'title': place.name,
         'subtitle': '${place.city} ${place.district} • ${place.category}',
         'image': imageUrl ?? 'https://cdn.pixabay.com/photo/2017/06/24/04/37/cloud-2436676_1280.jpg', // 기본 이미지 대체
+        'lat' : place.latitude.toString(), //위도
+        'lng' : place.longitude.toString() //경도
       });
     }
 

--- a/lib/views/my_page/plan_list_page.dart
+++ b/lib/views/my_page/plan_list_page.dart
@@ -29,7 +29,7 @@ class PlanListPage extends StatelessWidget {
             onTap: () {
               Navigator.push(
                 context,
-                MaterialPageRoute(builder: (_) => const SchedulePage()),
+                MaterialPageRoute(builder: (_) => const SchedulePage(userId: 'test-user', planId: 'test',)),//임시 데이터 넘김
               );
             },
             child: ScheduleCard(

--- a/lib/views/plan/location_setting/district_setting_page.dart
+++ b/lib/views/plan/location_setting/district_setting_page.dart
@@ -51,7 +51,7 @@ class _DistrictSettingPageState extends State<DistrictSettingPage> {
                   onPressed: () {
                     Navigator.push(
                       context,
-                      MaterialPageRoute(builder: (context) => SchedulePage()),
+                      MaterialPageRoute(builder: (context) => SchedulePage(userId: 'test-user', planId: 'test',)),//임시 데이터 넘김
                     );
                   },
                   child: Text(

--- a/lib/views/plan/place_search/place_search_page.dart
+++ b/lib/views/plan/place_search/place_search_page.dart
@@ -13,9 +13,26 @@ class PlaceSearchPage extends ConsumerStatefulWidget {
 
 class _PlaceSearchPageState extends ConsumerState<PlaceSearchPage> {
   final TextEditingController _searchController = TextEditingController();
+  final Set<int> _selectedIndexes = {};
 
   void _performSearch(String query) {
     ref.read(searchViewModelProvider.notifier).search(query.trim());
+    _selectedIndexes.clear(); // 검색 새로 하면 선택 초기화
+  }
+
+  void _toggleSelected(int index) {
+    setState(() {
+      if (_selectedIndexes.contains(index)) {
+        _selectedIndexes.remove(index);
+      } else {
+        _selectedIndexes.add(index);
+      }
+    });
+  }
+
+  void _confirmSelection(List<Map<String, String>> places) {
+    final selectedPlaces = _selectedIndexes.map((i) => places[i]).toList();
+    Navigator.pop(context, selectedPlaces); 
   }
 
   @override
@@ -37,10 +54,22 @@ class _PlaceSearchPageState extends ConsumerState<PlaceSearchPage> {
                 onSubmitted: _performSearch,
               ),
             ),
+            if (_selectedIndexes.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8),
+                child: ElevatedButton(
+                  onPressed: () => _confirmSelection(searchResults),
+                  child: const Text('선택 완료'),
+                ),
+              ),
             Expanded(
               child: searchResults.isEmpty
                   ? const Center(child: Text('검색 결과가 없습니다.'))
-                  : SearchResultList(places: searchResults),
+                  : SearchResultList(
+                      places: searchResults,
+                      selectedIndexes: _selectedIndexes,
+                      onToggle: _toggleSelected,
+                    ),
             ),
           ],
         ),

--- a/lib/views/plan/place_search/widgets/plan_place_card.dart
+++ b/lib/views/plan/place_search/widgets/plan_place_card.dart
@@ -1,21 +1,32 @@
 import 'package:flutter/material.dart';
 
 class PlanPlaceCard extends StatelessWidget {
-  const PlanPlaceCard({super.key, required this.place});
-  final Map<String, String> place;
+  const PlanPlaceCard({
+    super.key,
+    required this.place,
+    this.selected = false, // 선택 여부 기본값 false
+  });
 
+  final Map<String, String> place;
+  final bool selected;
 
   @override
   Widget build(BuildContext context) {
+    final imageUrl = place['image'];
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Container(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(16),
           color: Colors.white,
+          border: Border.all(
+            color: selected ? Colors.blue : Colors.transparent, // 선택 시 파란 테두리
+            width: 2,
+          ),
           boxShadow: [
             BoxShadow(
-              color: Color.fromRGBO(158, 158, 158, 0.1),
+              color: const Color.fromRGBO(158, 158, 158, 0.1),
               blurRadius: 8,
               offset: const Offset(0, 4),
             ),
@@ -25,36 +36,51 @@ class PlanPlaceCard extends StatelessWidget {
           borderRadius: BorderRadius.circular(16),
           child: Row(
             children: [
-              Image.network(
-                place['image']!,
-                width: 100,
-                height: 100,
-                fit: BoxFit.cover,
-              ),
-              const SizedBox(width: 16),
+              // 왼쪽 이미지
+              imageUrl != null && imageUrl.isNotEmpty
+                  ? Image.network(
+                      imageUrl,
+                      width: 100,
+                      height: 100,
+                      fit: BoxFit.cover,
+                    )
+                  : Container(
+                      width: 100,
+                      height: 100,
+                      color: Colors.grey[300],
+                    ),
+              const SizedBox(width: 12),
+              // 텍스트 + 체크 아이콘
               Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+                child: Row(
                   children: [
-                    Text(
-                      place['title']!,
-                      style: const TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.bold,
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            place['title'] ?? '',
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            place['subtitle'] ?? '',
+                            style: const TextStyle(
+                              fontSize: 14,
+                              color: Colors.grey,
+                            ),
+                          ),
+                        ],
                       ),
                     ),
-                    const SizedBox(height: 6),
-                    Text(
-                      place['subtitle']!,
-                      style: TextStyle(
-                        fontSize: 13,
-                        color: Colors.grey[700],
-                      ),
-                    ),
+                    if (selected)
+                      const Icon(Icons.check_circle, color: Colors.blue), // 체크 표시
                   ],
                 ),
               ),
-              const SizedBox(width: 16),
             ],
           ),
         ),

--- a/lib/views/plan/place_search/widgets/search_result_list.dart
+++ b/lib/views/plan/place_search/widgets/search_result_list.dart
@@ -1,17 +1,33 @@
-
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/views/plan/place_search/widgets/plan_place_card.dart';
 
 class SearchResultList extends StatelessWidget {
-  const SearchResultList({super.key, required this.places});
+  const SearchResultList({
+    super.key,
+    required this.places,
+    required this.selectedIndexes,
+    required this.onToggle,
+  });
+
   final List<Map<String, String>> places;
+  final Set<int> selectedIndexes;
+  final void Function(int index) onToggle;
 
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
       itemCount: places.length,
       itemBuilder: (context, index) {
-        return PlanPlaceCard(place: places[index]);
+        final place = places[index];
+        final isSelected = selectedIndexes.contains(index);
+
+        return GestureDetector(
+          onTap: () => onToggle(index),
+          child: PlanPlaceCard(
+            place: place,
+            selected: isSelected,
+          ),
+        );
       },
     );
   }

--- a/lib/views/plan/schedule/schedule_page.dart
+++ b/lib/views/plan/schedule/schedule_page.dart
@@ -65,6 +65,18 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
     }
   }
 
+//일정 삭제
+  void _removePlace(int dayIndex, int placeIndex) {
+  setState(() {
+    daySchedules[dayIndex]?.removeAt(placeIndex);
+  });
+
+  ref.read(scheduleViewModelProvider.notifier).saveDaySchedules(
+    planId: widget.planId,
+    daySchedules: daySchedules,
+  );
+}
+
   @override
   Widget build(BuildContext context) {
     final planState = ref.watch(scheduleViewModelProvider);
@@ -116,6 +128,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
                 isEditing: _isEditing,
                 onReorder: _onReorder,
                 onAddPlace: _addPlace,
+                onRemovePlace: _removePlace,
               );
             },
           );

--- a/lib/views/plan/schedule/schedule_page.dart
+++ b/lib/views/plan/schedule/schedule_page.dart
@@ -1,36 +1,29 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travel_muse_app/models/plans.dart';
+import 'package:travel_muse_app/providers/schedule_provider.dart';
 import 'package:travel_muse_app/views/plan/place_search/place_search_page.dart';
 import 'package:travel_muse_app/views/plan/schedule/widgets/day_schedule_section.dart';
 import 'package:travel_muse_app/views/plan/schedule/widgets/schedule_app_bar.dart';
 
-class SchedulePage extends StatefulWidget {
+class SchedulePage extends ConsumerStatefulWidget {
   const SchedulePage({super.key});
 
   @override
-  State<SchedulePage> createState() => _SchedulePageState();
+  ConsumerState<SchedulePage> createState() => _SchedulePageState();
 }
 
-class _SchedulePageState extends State<SchedulePage> {
-  //추후 실제 데이터 적용예정
-  final List<String> days = ['6.27/금', '6.28/토', '6.29/일'];
+class _SchedulePageState extends ConsumerState<SchedulePage> {
   bool _isEditing = false;
 
-  //추후 실제 데이터 적용예정
-  List<List<Map<String, String>>> daySchedules = [
-    [
-      {'title': '동문 새벽 시장', 'subtitle': '제주 쇼핑 명소', 'image': ''},
-      {'title': '함덕 해수욕장', 'subtitle': '구좌 해변', 'image': ''},
-    ],
-    [],
-    [],
-  ];
+  /// dayIndex -> 장소 리스트
+  final Map<int, List<Map<String, String>>> daySchedules = {};
 
-  //viewmodel 분리예정
   void _onReorder(int dayIndex, int oldIndex, int newIndex) {
     setState(() {
       if (newIndex > oldIndex) newIndex -= 1;
-      final movedItem = daySchedules[dayIndex].removeAt(oldIndex);
-      daySchedules[dayIndex].insert(newIndex, movedItem);
+      final movedItem = daySchedules[dayIndex]!.removeAt(oldIndex);
+      daySchedules[dayIndex]!.insert(newIndex, movedItem);
     });
   }
 
@@ -42,13 +35,16 @@ class _SchedulePageState extends State<SchedulePage> {
 
     if (selectedPlace != null) {
       setState(() {
-        daySchedules[dayIndex].add(selectedPlace);
+        daySchedules.putIfAbsent(dayIndex, () => []);
+        daySchedules[dayIndex]!.add(selectedPlace);
       });
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    final planState = ref.watch(scheduleViewModelProvider);
+
     return Scaffold(
       appBar: ScheduleAppBar(
         isEditing: _isEditing,
@@ -58,20 +54,45 @@ class _SchedulePageState extends State<SchedulePage> {
           });
         },
       ),
-      body: ListView.builder(
-        itemCount: days.length,
-        itemBuilder: (context, dayIndex) {
-          return DayScheduleSection(
-            key: ValueKey('day-$dayIndex'),
-            dayIndex: dayIndex,
-            dayLabel: days[dayIndex],
-            schedules: daySchedules[dayIndex],
-            isEditing: _isEditing,
-            onReorder: _onReorder,
-            onAddPlace: _addPlace,
+      body: planState.when(
+        data: (plans) {
+          if (plans.isEmpty) {
+            return const Center(child: Text('일정이 없습니다.'));
+          }
+
+          final plan = plans.first; // 우선 하나만 사용
+          final dayCount = plan.endDate.difference(plan.startDate).inDays + 1;
+
+          return ListView.builder(
+            itemCount: dayCount,
+            itemBuilder: (context, dayIndex) {
+              final currentDate =
+                  plan.startDate.add(Duration(days: dayIndex));
+              final dayLabel =
+                  '${currentDate.month}.${currentDate.day} (${_getWeekday(currentDate.weekday)})';
+
+              daySchedules.putIfAbsent(dayIndex, () => []);
+
+              return DayScheduleSection(
+                key: ValueKey('day-$dayIndex'),
+                dayIndex: dayIndex,
+                dayLabel: dayLabel,
+                schedules: daySchedules[dayIndex]!,
+                isEditing: _isEditing,
+                onReorder: _onReorder,
+                onAddPlace: _addPlace,
+              );
+            },
           );
         },
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('에러 발생: $e')),
       ),
     );
+  }
+
+  String _getWeekday(int weekday) {
+    const days = ['월', '화', '수', '목', '금', '토', '일'];
+    return days[weekday - 1];
   }
 }

--- a/lib/views/plan/schedule/widgets/day_schedule_section.dart
+++ b/lib/views/plan/schedule/widgets/day_schedule_section.dart
@@ -10,14 +10,16 @@ class DayScheduleSection extends StatelessWidget {
     required this.isEditing,
     required this.onReorder,
     required this.onAddPlace,
+    required this.onRemovePlace, 
   });
+
   final int dayIndex;
   final String dayLabel;
   final List<Map<String, String>> schedules;
   final bool isEditing;
   final void Function(int dayIndex, int oldIndex, int newIndex) onReorder;
   final void Function(int dayIndex) onAddPlace;
-
+  final void Function(int dayIndex, int placeIndex) onRemovePlace; 
 
   @override
   Widget build(BuildContext context) {
@@ -47,10 +49,21 @@ class DayScheduleSection extends StatelessWidget {
                 child: ReorderableDragStartListener(
                   index: i,
                   enabled: isEditing,
-                  child: SchedulePlaceCard(
-                    index: i + 1,
-                    place: place,
-                    showHandle: isEditing,
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: SchedulePlaceCard(
+                          index: i + 1,
+                          place: place,
+                          showHandle: isEditing,
+                        ),
+                      ),
+                      if (isEditing)
+                        IconButton(
+                          icon: const Icon(Icons.delete),
+                          onPressed: () => onRemovePlace(dayIndex, i),
+                        ),
+                    ],
                   ),
                 ),
               );

--- a/lib/views/plan/schedule/widgets/schedule_app_bar.dart
+++ b/lib/views/plan/schedule/widgets/schedule_app_bar.dart
@@ -1,4 +1,3 @@
-// widgets/schedule_app_bar.dart
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/views/location/map_page.dart';
 


### PR DESCRIPTION
### 🚀: 개요
- 일정 관리 CRUD 기능 구현

### 🚀: 작업 내용
- 여행 일정 관리 기능에 대해 편집·저장·불러오기를 포함한 전체 흐름 구축
- 일정 불러오기, 일별 장소 등록 및 순서 변경, Firestore 연동 저장/불러오기
- 선택 장소 삭제 기능

### 🚀: 조정 파일
- plans.dart
- schedule_page.dart
- schedule_provider.dart
- schedule_app_bar.dart
- schedule_view_model.dart
- day_schedule_section.dart
- plan_place_card.dart
- plan_list_page.dart
- search_result_list.dart
- search_view_model.dart
- place_search_page.dart
- district_setting_page.dart

###📸: 실행 화면
![Simulator Screenshot - iPhone 15 Pro Max - 2025-06-08 at 18 21 30](https://github.com/user-attachments/assets/b76d2bc9-112d-4bc4-8a16-4cf792db8503)
![Simulator Screenshot - iPhone 15 Pro Max - 2025-06-08 at 18 22 06](https://github.com/user-attachments/assets/f42bf4ce-1193-43bd-a564-169bde2e4cc4)
![Simulator Screenshot - iPhone 15 Pro Max - 2025-06-08 at 18 21 56](https://github.com/user-attachments/assets/1613a074-07f2-4e96-a672-c005738d64bf)

### 개발 결과
- 계획(plan) 필터링하여 불러오기 성공
- 날짜별 장소(route) 저장 및 로드 정상 작동
- 장소 추가/삭제/순서 변경 후 저장 동작 정상 확인
- 위도·경도 정보 저장 완료 (추후 지도 연동 준비 완료)
- 전체 흐름 MVVM 구조로 구현 완료 

### issue
Closes #54 
