### PR TITLE
[AI] AI 추천 여행 일정 기능 구현 및 저장 방식 분리

### DIFF
--- a/lib/repositories/plan_repository.dart
+++ b/lib/repositories/plan_repository.dart
@@ -1,5 +1,4 @@
-// lib/repositories/plan_repository.dart
-
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:travel_muse_app/services/ai_service.dart';
 
 class PlanRepository {
@@ -45,5 +44,24 @@ Day 2:
 ''';
 
     return await _aiService.generate(prompt);
+  }
+
+  Future<void> saveAiRoute({
+    required String planId,
+    required Map<int, List<Map<String, String>>> aiSchedules,
+  }) async {
+    final batch = FirebaseFirestore.instance.batch();
+
+    aiSchedules.forEach((dayIndex, places) {
+      final dayRef = FirebaseFirestore.instance
+          .collection('plans')
+          .doc(planId)
+          .collection('ai_route') // 서브컬렉션 분리 저장
+          .doc('day_$dayIndex');
+
+      batch.set(dayRef, {'places': places});
+    });
+
+    await batch.commit();
   }
 }

--- a/lib/repositories/plan_repository.dart
+++ b/lib/repositories/plan_repository.dart
@@ -23,45 +23,34 @@ class PlanRepository {
     final prompt = '''
 너는 여행 플래너야.
 
-다음 조건을 참고해서 여행자에게 맞는 여행 계획을 작성해줘.
+여행자에게 맞는 일정표를 아래 조건에 따라 만들어줘:
 
 - 여행일수: ${days}일
-- 지역: $region
+- 여행 지역: $region
 - 여행자 성향: $typeDescription
 
-각 날짜별로 추천 장소와 간단한 설명을 아래 형식으로 작성해줘. 추가 설명 없이 일정만 반환해.
+📌 아래 형식대로만 응답해줘. 설명 없이 **일정표만** 반환해.
 
-예시:
+---
 Day 1:
+- 장소1: 간단한 설명1
+- 장소2: 간단한 설명2
+
+Day 2:
+- 장소1: 간단한 설명1
+- 장소2: 간단한 설명2
+...
+
+Day N:
 - 장소1: 설명1
 - 장소2: 설명2
 
-Day 2:
-- 장소1: 설명1
-...
 
-꼭 위 포맷을 지켜줘.
+반드시 위 형식을 그대로 지켜줘. **장소명 앞에 '- '**, 줄바꿈, 'Day N:'은 꼭 포함해줘.
+장소는 유명하거나 대표적인 곳 위주로 작성하고, 너무 많은 장소는 넣지 마.
+※ 장소명은 '__' 같은 특수문자 없이 실제 장소 이름으로 작성해줘.
 ''';
 
     return await _aiService.generate(prompt);
-  }
-
-  Future<void> saveAiRoute({
-    required String planId,
-    required Map<int, List<Map<String, String>>> aiSchedules,
-  }) async {
-    final batch = FirebaseFirestore.instance.batch();
-
-    aiSchedules.forEach((dayIndex, places) {
-      final dayRef = FirebaseFirestore.instance
-          .collection('plans')
-          .doc(planId)
-          .collection('ai_route') // 서브컬렉션 분리 저장
-          .doc('day_$dayIndex');
-
-      batch.set(dayRef, {'places': places});
-    });
-
-    await batch.commit();
   }
 }

--- a/lib/repositories/plan_repository.dart
+++ b/lib/repositories/plan_repository.dart
@@ -1,0 +1,49 @@
+// lib/repositories/plan_repository.dart
+
+import 'package:travel_muse_app/services/ai_service.dart';
+
+class PlanRepository {
+  final _aiService = AiService();
+
+  final Map<String, String> _typeDescriptions = {
+    'planner': '철두철미 계획러: 여행은 미리미리! 엑셀표까지 만들어야 마음이 놓이죠.',
+    'free_spirit': '자유로운 방랑자: 즉흥 여행이 진짜 여행! 발 닿는 대로 떠나요.',
+    'nature_lover': '숲속 힐러: 사람보다 나무가 좋을 때, 자연 속 쉼이 최고의 여정입니다.',
+    'city_explorer': '도시 정복자: 랜드마크와 핫플 투어는 빠짐없이, 감각적인 여행을 즐깁니다.',
+    'balanced_traveler': '밸런스 마스터: 일정은 짜되, 여유도 챙기는 여행 스타일의 고수입니다.',
+    'experience_seeker': '체험형 모험가: 먹어보고, 타보고, 느껴보며 오감으로 기억하는 여행러!',
+  };
+
+  Future<String> getOptimizedPlanFromAI({
+    required int days,
+    required String region,
+    required String typeCode,
+  }) async {
+    final typeDescription = _typeDescriptions[typeCode] ?? typeCode;
+
+    final prompt = '''
+너는 여행 플래너야.
+
+다음 조건을 참고해서 여행자에게 맞는 여행 계획을 작성해줘.
+
+- 여행일수: ${days}일
+- 지역: $region
+- 여행자 성향: $typeDescription
+
+각 날짜별로 추천 장소와 간단한 설명을 아래 형식으로 작성해줘. 추가 설명 없이 일정만 반환해.
+
+예시:
+Day 1:
+- 장소1: 설명1
+- 장소2: 설명2
+
+Day 2:
+- 장소1: 설명1
+...
+
+꼭 위 포맷을 지켜줘.
+''';
+
+    return await _aiService.generate(prompt);
+  }
+}

--- a/lib/repositories/preference_test_repository.dart
+++ b/lib/repositories/preference_test_repository.dart
@@ -18,11 +18,10 @@ class PreferenceTestRepository {
   Future<PreferenceTest> classifyTestOnly(
     List<Map<String, String>> answersRaw,
   ) async {
-    /*TODO:개발단계 끝나면 주석 제거
-    final currentUser = FirebaseAuth.instance.currentUser;
-  if (currentUser == null) {
-    throw Exception('로그인되지 않은 상태에서는 테스트를 저장할 수 없습니다.');
-  }*/
+    // final currentUser = FirebaseAuth.instance.currentUser;
+    // if (currentUser == null) {
+    //   throw Exception('로그인되지 않은 상태에서는 테스트를 저장할 수 없습니다.');
+    // }
 
     final resultSummary = answersRaw
         .map((a) => '${a['question']} => ${a['selectedOption']}')

--- a/lib/repositories/schedule_repository.dart
+++ b/lib/repositories/schedule_repository.dart
@@ -3,10 +3,9 @@ import 'package:travel_muse_app/models/plans.dart';
 
 class ScheduleRepository {
   ScheduleRepository({FirebaseFirestore? firestore})
-      : _firestore = firestore ?? FirebaseFirestore.instance;
-      
-  final FirebaseFirestore _firestore;
+    : _firestore = firestore ?? FirebaseFirestore.instance;
 
+  final FirebaseFirestore _firestore;
 
   Future<List<Plans>> fetchPlans([String? userId]) async {
     Query query = _firestore.collection('plans');
@@ -16,7 +15,9 @@ class ScheduleRepository {
 
     final snapshot = await query.get();
     return snapshot.docs
-        .map((doc) => Plans.fromJson(doc.id, doc.data() as Map<String, dynamic>))
+        .map(
+          (doc) => Plans.fromJson(doc.id, doc.data() as Map<String, dynamic>),
+        )
         .toList();
   }
 
@@ -33,20 +34,19 @@ class ScheduleRepository {
           .collection('route')
           .doc('day_$dayIndex');
 
-      batch.set(dayRef, {
-        'places': places,
-      });
+      batch.set(dayRef, {'places': places});
     });
 
     await batch.commit();
   }
 
   Future<Map<int, List<Map<String, String>>>> fetchRoute(String planId) async {
-    final snapshot = await _firestore
-        .collection('plans')
-        .doc(planId)
-        .collection('route')
-        .get();
+    final snapshot =
+        await _firestore
+            .collection('plans')
+            .doc(planId)
+            .collection('route')
+            .get();
 
     final result = <int, List<Map<String, String>>>{};
 
@@ -54,9 +54,10 @@ class ScheduleRepository {
       final key = int.tryParse(doc.id.replaceFirst('day_', ''));
       if (key != null) {
         final data = doc.data();
-        final places = (data['places'] as List)
-            .map((e) => Map<String, String>.from(e))
-            .toList();
+        final places =
+            (data['places'] as List)
+                .map((e) => Map<String, String>.from(e))
+                .toList();
         result[key] = places;
       }
     }

--- a/lib/repositories/schedule_repository.dart
+++ b/lib/repositories/schedule_repository.dart
@@ -40,6 +40,25 @@ class ScheduleRepository {
     await batch.commit();
   }
 
+  Future<void> saveAiRoute({
+    required String planId,
+    required Map<int, List<Map<String, String>>> aiSchedules,
+  }) async {
+    final batch = FirebaseFirestore.instance.batch();
+
+    aiSchedules.forEach((dayIndex, places) {
+      final dayRef = FirebaseFirestore.instance
+          .collection('plans')
+          .doc(planId)
+          .collection('ai_route')
+          .doc('day_$dayIndex');
+
+      batch.set(dayRef, {'places': places});
+    });
+
+    await batch.commit();
+  }
+
   Future<Map<int, List<Map<String, String>>>> fetchRoute(String planId) async {
     final snapshot =
         await _firestore

--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -10,4 +10,9 @@ class AiService {
     final result = await _model.generateContent([Content.text(prompt)]);
     return result.text?.trim() ?? '';
   }
+
+  Future<String> generate(String prompt) async {
+    final result = await _model.generateContent([Content.text(prompt)]);
+    return result.text?.trim() ?? '';
+  }
 }

--- a/lib/utills/date_utils.dart
+++ b/lib/utills/date_utils.dart
@@ -1,0 +1,25 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// 시작일(start)과 종료일(end)을 받아 여행일수를 계산한다.
+/// - Timestamp 또는 DateTime 모두 지원
+/// - 동일 날짜도 1일로 계산
+int calculateTripDays(dynamic start, dynamic end) {
+  DateTime? startDate;
+  DateTime? endDate;
+
+  if (start is Timestamp) {
+    startDate = start.toDate();
+  } else if (start is DateTime) {
+    startDate = start;
+  }
+
+  if (end is Timestamp) {
+    endDate = end.toDate();
+  } else if (end is DateTime) {
+    endDate = end;
+  }
+
+  if (startDate == null || endDate == null) return 1;
+
+  return endDate.difference(startDate).inDays + 1;
+}

--- a/lib/viewmodels/schedule_view_model.dart
+++ b/lib/viewmodels/schedule_view_model.dart
@@ -30,12 +30,23 @@ class ScheduleViewModel extends StateNotifier<AsyncValue<List<Plans>>> {
     );
   }
 
-  /// daySchedules 저장
+  /// daySchedules 수동 입력 저장용
   Future<void> saveDaySchedules({
     required String planId,
     required Map<int, List<Map<String, String>>> daySchedules,
   }) async {
-    await _repository.saveDaySchedules(planId: planId, daySchedules: daySchedules);
+    await _repository.saveDaySchedules(
+      planId: planId,
+      daySchedules: daySchedules,
+    );
+  }
+
+  /// AI 추천 일정 저장용
+  Future<void> saveAiSchedules({
+    required String planId,
+    required Map<int, List<Map<String, String>>> daySchedules,
+  }) async {
+    await _repository.saveAiRoute(planId: planId, aiSchedules: daySchedules);
   }
 
   /// route 불러오기

--- a/lib/views/plan/schedule/schedule_page.dart
+++ b/lib/views/plan/schedule/schedule_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/models/plans.dart';
 import 'package:travel_muse_app/providers/schedule_provider.dart';
+import 'package:travel_muse_app/utills/date_utils.dart';
 import 'package:travel_muse_app/views/plan/place_search/place_search_page.dart';
 import 'package:travel_muse_app/views/plan/schedule/widgets/ai_button.dart';
 import 'package:travel_muse_app/views/plan/schedule/widgets/day_schedule_section.dart';
@@ -104,7 +105,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
                   TextButton(
                     style: TextButton.styleFrom(
                       padding: EdgeInsets.zero,
-                      minimumSize: const Size(32, 27), 
+                      minimumSize: const Size(32, 27),
                       tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     ),
                     onPressed: () async {
@@ -120,7 +121,12 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
                     },
                     child: Text(
                       _isEditing ? '완료' : '편집',
-                      style: TextStyle(color: AppColors.primary[500], fontFamily: 'Pretendard', fontSize: 18, fontWeight: FontWeight.w400),
+                      style: TextStyle(
+                        color: AppColors.primary[500],
+                        fontFamily: 'Pretendard',
+                        fontSize: 18,
+                        fontWeight: FontWeight.w400,
+                      ),
                     ),
                   ),
                 ],
@@ -170,7 +176,28 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
           ],
         ),
       ),
-      floatingActionButton: AiButton(),
+      floatingActionButton:
+          selectedPlan == null
+              ? null
+              : AiButton(
+                planId: widget.planId,
+                days: calculateTripDays(
+                  selectedPlan!.startDate,
+                  selectedPlan!.endDate,
+                ),
+                region: selectedPlan!.region,
+                onResult: (parsed) {
+                  setState(() {
+                    daySchedules = parsed;
+                  });
+                  ref
+                      .read(scheduleViewModelProvider.notifier)
+                      .saveDaySchedules(
+                        planId: widget.planId,
+                        daySchedules: parsed,
+                      );
+                },
+              ),
       bottomNavigationBar: ScheduleBottomButtons(),
     );
   }

--- a/lib/views/plan/schedule/schedule_page.dart
+++ b/lib/views/plan/schedule/schedule_page.dart
@@ -192,7 +192,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
                   });
                   ref
                       .read(scheduleViewModelProvider.notifier)
-                      .saveDaySchedules(
+                      .saveAiSchedules(
                         planId: widget.planId,
                         daySchedules: parsed,
                       );

--- a/lib/views/plan/schedule/widgets/ai_button.dart
+++ b/lib/views/plan/schedule/widgets/ai_button.dart
@@ -1,24 +1,56 @@
 import 'package:flutter/material.dart';
+import 'package:travel_muse_app/repositories/plan_repository.dart';
+import 'package:travel_muse_app/views/plan/schedule/widgets/ai_type_select_popup.dart';
 import 'package:travel_muse_app/views/plan/schedule/widgets/ground_circle_icon.dart';
 
 class AiButton extends StatelessWidget {
-  const AiButton({super.key, 
-  // required this.onTap
+  const AiButton({
+    super.key,
+    required this.planId,
+    required this.days,
+    required this.region,
+    required this.onResult,
   });
-  // final VoidCallback onTap;
+
+  final String planId;
+  final int days;
+  final String region;
+  final void Function(Map<int, List<Map<String, String>>>) onResult;
 
   @override
   Widget build(BuildContext context) {
     return FloatingActionButton.extended(
-      onPressed: (){
+      onPressed: () {
+        showDialog(
+          context: context,
+          builder:
+              (_) => AiTypeSelectPopup(
+                onComplete: (selectedTest) async {
+                  final typeCode = selectedTest;
+                  final aiPlan = await PlanRepository().getOptimizedPlanFromAI(
+                    days: days,
+                    region: region,
+                    typeCode: typeCode,
+                  );
 
+                  final parsed = _parseAiPlan(aiPlan);
+
+                  await PlanRepository().saveAiRoute(
+                    planId: planId,
+                    aiSchedules: parsed,
+                  );
+
+                  onResult(parsed);
+                },
+              ),
+        );
       },
-      backgroundColor: Colors.transparent,   // 그라데이션 넣기 위해 투명
+      backgroundColor: Colors.transparent,
       elevation: 0,
       label: Container(
         decoration: const BoxDecoration(
           gradient: LinearGradient(
-            colors: [Colors.white,Color(0xFF49CDFE), Color(0xFF1572FD)],
+            colors: [Colors.white, Color(0xFF49CDFE), Color(0xFF1572FD)],
             begin: Alignment.centerLeft,
             end: Alignment.centerRight,
           ),
@@ -27,10 +59,10 @@ class AiButton extends StatelessWidget {
         padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 10),
         child: Row(
           mainAxisSize: MainAxisSize.min,
-          children: [
-            const GradientCircleIcon(size: 20),  
-            const SizedBox(width: 8),
-            const Text(
+          children: const [
+            GradientCircleIcon(size: 20),
+            SizedBox(width: 8),
+            Text(
               'Ai 추천 받기',
               style: TextStyle(
                 color: Colors.white,
@@ -43,5 +75,30 @@ class AiButton extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Map<int, List<Map<String, String>>> _parseAiPlan(String result) {
+    final lines = result.split('\n');
+    final Map<int, List<Map<String, String>>> parsed = {};
+    int? currentDay;
+
+    for (var line in lines) {
+      if (line.startsWith('Day')) {
+        final dayMatch = RegExp(r'Day (\d+)').firstMatch(line);
+        if (dayMatch != null) {
+          currentDay = int.parse(dayMatch.group(1)!);
+          parsed[currentDay - 1] = [];
+        }
+      } else if (currentDay != null && line.trim().startsWith('-')) {
+        final parts = line.replaceFirst('- ', '').split(':');
+        final title = parts[0].trim();
+        final description = parts.length > 1 ? parts[1].trim() : '';
+        parsed[currentDay - 1]!.add({
+          'title': title,
+          'description': description,
+        });
+      }
+    }
+    return parsed;
   }
 }

--- a/lib/views/plan/schedule/widgets/ai_type_select_popup.dart
+++ b/lib/views/plan/schedule/widgets/ai_type_select_popup.dart
@@ -1,0 +1,101 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:travel_muse_app/models/preference_test_model.dart';
+
+class AiTypeSelectPopup extends StatefulWidget {
+  const AiTypeSelectPopup({super.key, required this.onComplete});
+  final void Function(String typeCode) onComplete;
+
+  @override
+  State<AiTypeSelectPopup> createState() => _AiTypeSelectPopupState();
+}
+
+class _AiTypeSelectPopupState extends State<AiTypeSelectPopup> {
+  List<PreferenceTest> _tests = [];
+  PreferenceTest? _selectedTest;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchTests();
+  }
+
+  Future<void> _fetchTests() async {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return;
+
+    final query =
+        await FirebaseFirestore.instance
+            .collection('preference_test')
+            .where('userId', isEqualTo: uid)
+            .orderBy('createdAt', descending: true)
+            .get();
+
+    final tests =
+        query.docs
+            .map((doc) => PreferenceTest.fromDoc(doc.id, doc.data()))
+            .toList();
+
+    setState(() {
+      _tests = tests;
+      if (_tests.isNotEmpty) {
+        _selectedTest = _tests.first;
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      title: const Text(
+        'Ai 추천 받을 성향을 선택해주세요',
+        style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children:
+            _tests.map((test) {
+              final isSelected = _selectedTest?.testId == test.testId;
+              final type = test.result['type'];
+              return ListTile(
+                title: Text(
+                  '성향: $type',
+                  style: const TextStyle(fontWeight: FontWeight.w600),
+                ),
+                leading: Radio<String>(
+                  value: test.testId,
+                  groupValue: _selectedTest?.testId,
+                  onChanged: (_) => setState(() => _selectedTest = test),
+                  activeColor: Colors.lightBlueAccent,
+                ),
+              );
+            }).toList(),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('취소'),
+        ),
+        ElevatedButton(
+          onPressed:
+              _selectedTest == null
+                  ? null
+                  : () {
+                    Navigator.pop(context);
+                    final typeCode = _selectedTest!.result['type'];
+                    widget.onComplete(typeCode!);
+                  },
+          style: ElevatedButton.styleFrom(
+            backgroundColor: const Color(0xFF48CDFD),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10),
+            ),
+          ),
+          child: const Text('완료'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/plan/schedule/widgets/ai_type_select_popup.dart
+++ b/lib/views/plan/schedule/widgets/ai_type_select_popup.dart
@@ -29,7 +29,6 @@ class _AiTypeSelectPopupState extends State<AiTypeSelectPopup> {
         await FirebaseFirestore.instance
             .collection('preference_test')
             .where('userId', isEqualTo: uid)
-            .orderBy('createdAt', descending: true)
             .get();
 
     final tests =


### PR DESCRIPTION
### 🚀: 개요
AI 추천 여행 일정 기능 구현 및 저장 방식 분리

### 🚀: 작업 내용
AI 여행 일정 생성 프롬프트 수정 (형식 고정 + 특수문자 제한)

PlanRepository.getOptimizedPlanFromAI() 프롬프트 개선

saveDaySchedules() (수동 입력용) vs saveAiRoute() (AI 일정 저장용) 분리 적용

AiTypeSelectPopup에서 성향 선택 후 프롬프트 호출 및 ai_route 저장 처리

AiButton에서 수동 저장(route)과 AI 저장(ai_route) 분기 처리 적용



📸: 실행 화면
 <img src="https://github.com/user-attachments/assets/8e5718e9-19aa-451b-94d3-03b11b243319" width="300" height="600"/>
 <img src="https://github.com/user-attachments/assets/677fc664-cd43-41e4-9825-d018eff74910" width="300" height="600"/>


### 🚀: 조정 파일
plan_repository.dart

schedule_view_model.dart

schedule_repository.dart

ai_type_select_popup.dart

ai_button.dart

### 개발 결과
AI 여행 일정 자동 생성 및 저장 기능 구현 완료

수동/자동 일정 저장 로직 분리로 데이터 충돌 방지

### issue
Closes #77 
