### PR TITLE
[Login] 로그인 상태 전역관리 및 홈/로그인 화면 분기

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1437,6 +1437,9 @@ PODS:
     - FlutterMacOS
   - PromisesObjC (2.4.0)
   - RecaptchaInterop (101.0.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - url_launcher_ios (0.0.1):
     - Flutter
 
@@ -1450,6 +1453,7 @@ DEPENDENCIES:
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
 
 SPEC REPOS:
@@ -1501,6 +1505,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/image_picker_ios/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   url_launcher_ios:
     :path: ".symlinks/plugins/url_launcher_ios/ios"
 
@@ -1541,6 +1547,7 @@ SPEC CHECKSUMS:
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
 
 PODFILE CHECKSUM: e30f02f9d1c72c47bb6344a0a748c9d268180865

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,7 +25,9 @@ class MyApp extends StatelessWidget {
         scaffoldBackgroundColor: Colors.white,
         appBarTheme: const AppBarTheme(backgroundColor: Colors.white),
       ),
-      home: StreamBuilder<User?>(
+      home:
+      // 로그인 상태에 따라 로그인/홈 분기
+      StreamBuilder<User?>(
         stream: FirebaseAuth.instance.authStateChanges(),
         builder: (context, snapshot) {
           final user = snapshot.data;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,11 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/firebase_options.dart';
+import 'package:travel_muse_app/views/home/home_page.dart';
+import 'package:travel_muse_app/views/login/login_page.dart';
 import 'package:travel_muse_app/views/splash/splash_page.dart';
 
 void main() async {
@@ -22,7 +25,15 @@ class MyApp extends StatelessWidget {
         scaffoldBackgroundColor: Colors.white,
         appBarTheme: const AppBarTheme(backgroundColor: Colors.white),
       ),
-      home: const SplashPage(),
+      home: StreamBuilder<User?>(
+        stream: FirebaseAuth.instance.authStateChanges(),
+        builder: (context, snapshot) {
+          final user = snapshot.data;
+          final Widget target =
+              user == null ? const LoginPage() : const HomePage();
+          return SplashPage(firstPagebyLoginState: target);
+        },
+      ),
     );
   }
 }

--- a/lib/repositories/app_user_repository.dart
+++ b/lib/repositories/app_user_repository.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
+import 'package:travel_muse_app/models/app_user_model.dart';
 
 class AppUserRepository {
   final _firestore = FirebaseFirestore.instance;
@@ -23,6 +24,18 @@ class AppUserRepository {
         'gender': null,
       });
     }
+  }
+
+  // 데이터베이스에서 유저 정보 get
+  Future<AppUser?> fetchLatestAppUser(String uid) async {
+    final doc =
+        await FirebaseFirestore.instance.collection('AppUsers').doc(uid).get();
+    if (doc.data() == null) {
+      return null;
+      // TODO: 뷰모델에서 유저 정보 없는 경우 처리
+      // '세션이 만료되었습니다. 다시 로그인해 주세요.' - 강제 로그아웃, 재로그인 유도
+    }
+    return AppUser.fromJson(doc.data()!);
   }
 
   // 유저 닉네임 중복확인

--- a/lib/viewmodels/auth_view_model.dart
+++ b/lib/viewmodels/auth_view_model.dart
@@ -44,8 +44,6 @@ class AuthViewModel extends Notifier<AuthState> {
     await _authService.signOut();
     state = AuthState(); // 초기화
   }
-
-  // TODO: 로그인 성공 시 Home으로 or 온보딩으로 이동 조건 분기 메서드
 }
 
 final authViewModelProvider = NotifierProvider<AuthViewModel, AuthState>(

--- a/lib/views/splash/splash_page.dart
+++ b/lib/views/splash/splash_page.dart
@@ -1,9 +1,10 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:travel_muse_app/views/home/home_page.dart';
 
 class SplashPage extends StatefulWidget {
-  const SplashPage({super.key});
+  const SplashPage({super.key, required this.firstPagebyLoginState});
+
+  final Widget firstPagebyLoginState;
 
   @override
   State<SplashPage> createState() => _SplashScreenState();
@@ -17,7 +18,7 @@ class _SplashScreenState extends State<SplashPage> {
     Timer(const Duration(seconds: 2), () {
       Navigator.pushReplacement(
         context,
-        MaterialPageRoute(builder: (context) => const HomePage()),
+        MaterialPageRoute(builder: (context) => widget.firstPagebyLoginState),
       );
     });
   }


### PR DESCRIPTION
### 🚀: 개요
- 로그인 상태 전역관리, 홈/로그인 화면 분기

### 🚀: 작업 내용
- stream으로 로그인 상태 감시, 스플래시 페이지 네비게이터에 분기로 사용
- 최신 appUser get로직

### 📸: 실행 화면

### 🚀: 조정 파일
- main.dart
- app_user_repository.dart
- splash_page.dart

### 개발 결과
- 로그인 상태 전역관리 구현 완료
- 로그인 상태에 따라 페이지 이동 구현 완료

### issue
Closes #87
