### PR TITLE
[Plan] 지역/캘린더 + 세부 계획 파이어베이스 통합 연결

### DIFF
--- a/lib/repositories/calendar_location_repository.dart
+++ b/lib/repositories/calendar_location_repository.dart
@@ -11,7 +11,7 @@ class CalendarLocationRepository {
     required DateTime startDate,
     required DateTime endDate,
     required String region,
-    required String userId, // 추가
+    required String userId,
   }) async {
     final duration = endDate.difference(startDate).inDays + 1;
 
@@ -20,7 +20,7 @@ class CalendarLocationRepository {
       'endDate': Timestamp.fromDate(endDate),
       'duration': duration,
       'region': region,
-      'userId': userId, // 추가
+      'userId': userId,
     }, SetOptions(merge: true));
   }
 
@@ -28,7 +28,7 @@ class CalendarLocationRepository {
     required DateTime startDate,
     required DateTime endDate,
     required String region,
-    required String userId, // 추가
+    required String userId,
   }) async {
     final duration = endDate.difference(startDate).inDays + 1;
 
@@ -40,7 +40,7 @@ class CalendarLocationRepository {
       'endDate': Timestamp.fromDate(endDate),
       'duration': duration,
       'region': region,
-      'userId': userId, // 추가
+      'userId': userId,
     });
 
     return planId;

--- a/lib/repositories/calendar_location_repository.dart
+++ b/lib/repositories/calendar_location_repository.dart
@@ -11,6 +11,7 @@ class CalendarLocationRepository {
     required DateTime startDate,
     required DateTime endDate,
     required String region,
+    required String userId, // 추가
   }) async {
     final duration = endDate.difference(startDate).inDays + 1;
 
@@ -19,6 +20,7 @@ class CalendarLocationRepository {
       'endDate': Timestamp.fromDate(endDate),
       'duration': duration,
       'region': region,
+      'userId': userId, // 추가
     }, SetOptions(merge: true));
   }
 
@@ -26,6 +28,7 @@ class CalendarLocationRepository {
     required DateTime startDate,
     required DateTime endDate,
     required String region,
+    required String userId, // 추가
   }) async {
     final duration = endDate.difference(startDate).inDays + 1;
 
@@ -37,6 +40,7 @@ class CalendarLocationRepository {
       'endDate': Timestamp.fromDate(endDate),
       'duration': duration,
       'region': region,
+      'userId': userId, // 추가
     });
 
     return planId;

--- a/lib/viewmodels/auth_view_model.dart
+++ b/lib/viewmodels/auth_view_model.dart
@@ -21,7 +21,10 @@ class AuthViewModel extends Notifier<AuthState> {
   final _appUserRepository = AppUserRepository();
 
   @override
-  AuthState build() => AuthState();
+  AuthState build() {
+    final currentUser = FirebaseAuth.instance.currentUser;
+    return AuthState(user: currentUser);
+  }
 
   // 성공 시 상태 갱신, 실패 시 log 출력
   Future<void> loginWithGoogle() async {

--- a/lib/viewmodels/calendar_location_view_model.dart
+++ b/lib/viewmodels/calendar_location_view_model.dart
@@ -51,7 +51,7 @@ class CalendarLocationViewModel extends StateNotifier<PlanState> {
       startDate: start,
       endDate: end,
       region: region,
-      userId: userId, // 전달
+      userId: userId,
     );
   }
 
@@ -71,7 +71,7 @@ class CalendarLocationViewModel extends StateNotifier<PlanState> {
       startDate: start,
       endDate: end,
       region: region,
-      userId: userId, // 전달
+      userId: userId,
     );
 
     return planId;

--- a/lib/viewmodels/calendar_location_view_model.dart
+++ b/lib/viewmodels/calendar_location_view_model.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/providers/calendar_location_provider.dart';
+import 'package:travel_muse_app/viewmodels/auth_view_model.dart';
 
 class PlanState {
   PlanState({this.startDate, this.endDate, this.region});
@@ -38,9 +39,10 @@ class CalendarLocationViewModel extends StateNotifier<PlanState> {
     final start = state.startDate;
     final end = state.endDate;
     final region = state.region;
+    final userId = ref.read(authViewModelProvider).user?.uid;
 
-    if (start == null || end == null || region == null) {
-      throw Exception("날짜 또는 지역 정보가 누락되었습니다.");
+    if (start == null || end == null || region == null || userId == null) {
+      throw Exception("날짜, 지역 또는 사용자 정보가 누락되었습니다.");
     }
 
     final repo = ref.read(calendarLocationRepositoryProvider);
@@ -49,6 +51,7 @@ class CalendarLocationViewModel extends StateNotifier<PlanState> {
       startDate: start,
       endDate: end,
       region: region,
+      userId: userId, // 전달
     );
   }
 
@@ -57,9 +60,10 @@ class CalendarLocationViewModel extends StateNotifier<PlanState> {
     final start = state.startDate;
     final end = state.endDate;
     final region = state.region;
+    final userId = ref.read(authViewModelProvider).user?.uid;
 
-    if (start == null || end == null || region == null) {
-      throw Exception("날짜 또는 지역 정보가 누락되었습니다.");
+    if (start == null || end == null || region == null || userId == null) {
+      throw Exception("날짜, 지역 또는 사용자 정보가 누락되었습니다.");
     }
 
     final repo = ref.read(calendarLocationRepositoryProvider);
@@ -67,6 +71,7 @@ class CalendarLocationViewModel extends StateNotifier<PlanState> {
       startDate: start,
       endDate: end,
       region: region,
+      userId: userId, // 전달
     );
 
     return planId;

--- a/lib/views/home/widgets/travel_register_button.dart
+++ b/lib/views/home/widgets/travel_register_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/core/widgets/svg_icon.dart';
+import 'package:travel_muse_app/views/calendar/calendar_page.dart';
 import 'package:travel_muse_app/views/plan/schedule/schedule_page.dart';
 
 class TravelRegisterButton extends StatelessWidget {
@@ -50,7 +51,9 @@ class TravelRegisterButton extends StatelessWidget {
             onTap: () {
               Navigator.push(
                 context,
-                MaterialPageRoute(builder: (_) => const SchedulePage( userId: 'test-user', planId: 'test')),
+                MaterialPageRoute(
+                  builder: (_) => const CalendarPage(),
+                ), // userId: 'test-user', planId: 'test'
               );
             },
             child: Container(

--- a/lib/views/plan/location_setting/district_setting_page.dart
+++ b/lib/views/plan/location_setting/district_setting_page.dart
@@ -108,7 +108,6 @@ class _DistrictSettingPageState extends ConsumerState<DistrictSettingPage> {
                             try {
                               final userId =
                                   ref.watch(authViewModelProvider).user?.uid;
-                              print('현재 로그인된 유저 아이디: $userId');
 
                               if (userId == null) {
                                 ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/views/plan/location_setting/district_setting_page.dart
+++ b/lib/views/plan/location_setting/district_setting_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/core/region_data.dart';
 import 'package:travel_muse_app/providers/calendar_location_provider.dart';
 import 'package:travel_muse_app/providers/calendar_provider.dart';
+import 'package:travel_muse_app/viewmodels/auth_view_model.dart';
 import 'package:travel_muse_app/views/plan/location_setting/widgets/district_box_list.dart';
 import 'package:travel_muse_app/views/plan/schedule/schedule_page.dart';
 
@@ -105,15 +106,28 @@ class _DistrictSettingPageState extends ConsumerState<DistrictSettingPage> {
                             }
 
                             try {
+                              final userId =
+                                  ref.read(authViewModelProvider).user?.uid;
+
+                              if (userId == null) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('로그인 정보가 없습니다.'),
+                                  ),
+                                );
+                                return;
+                              }
+
                               final planId =
                                   await locationViewModel.createAndSavePlan();
+
                               if (context.mounted) {
                                 await Navigator.pushReplacement(
                                   context,
                                   MaterialPageRoute(
                                     builder:
                                         (_) => SchedulePage(
-                                          userId: '',
+                                          userId: userId,
                                           planId: planId,
                                         ),
                                   ),

--- a/lib/views/plan/location_setting/district_setting_page.dart
+++ b/lib/views/plan/location_setting/district_setting_page.dart
@@ -107,7 +107,8 @@ class _DistrictSettingPageState extends ConsumerState<DistrictSettingPage> {
 
                             try {
                               final userId =
-                                  ref.read(authViewModelProvider).user?.uid;
+                                  ref.watch(authViewModelProvider).user?.uid;
+                              print('현재 로그인된 유저 아이디: $userId');
 
                               if (userId == null) {
                                 ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/views/plan/schedule/schedule_page.dart
+++ b/lib/views/plan/schedule/schedule_page.dart
@@ -54,7 +54,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
   Future<void> _addPlace(int dayIndex) async {
     final selectedPlaces = await Navigator.push<List<Map<String, String>>>(
       context,
-      MaterialPageRoute(builder: (_) =>  PlaceSearchPage(planId:widget.planId,)),
+      MaterialPageRoute(builder: (_) => PlaceSearchPage(planId: widget.planId)),
     );
 
     if (selectedPlaces != null && selectedPlaces.isNotEmpty) {
@@ -198,7 +198,19 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
                       );
                 },
               ),
-      bottomNavigationBar: ScheduleBottomButtons(),
+      bottomNavigationBar: ScheduleBottomButtons(
+        onEditTap: () async {
+          await ref
+              .read(scheduleViewModelProvider.notifier)
+              .saveDaySchedules(
+                planId: widget.planId,
+                daySchedules: daySchedules,
+              );
+          ScaffoldMessenger.of(
+            context,
+          ).showSnackBar(const SnackBar(content: Text('일정이 저장되었습니다.')));
+        },
+      ),
     );
   }
 
@@ -207,4 +219,3 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
     return days[weekday - 1];
   }
 }
-

--- a/lib/views/plan/schedule/widgets/schedule_bottom_button.dart
+++ b/lib/views/plan/schedule/widgets/schedule_bottom_button.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/material.dart';
 
 class ScheduleBottomButtons extends StatelessWidget {
-  const ScheduleBottomButtons({super.key, 
-  // required this.onEditTap
-  });
+  const ScheduleBottomButtons({super.key, required this.onEditTap});
 
-  // final VoidCallback onEditTap;
+  final VoidCallback onEditTap;
 
   static const _blueGrad = LinearGradient(
     colors: [Color(0xFF42A5FF), Color(0xFF67C5FF)],
@@ -18,7 +16,7 @@ class ScheduleBottomButtons extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
       child: GestureDetector(
-        // onTap: onEditTap,
+        onTap: onEditTap,
         child: Container(
           height: 48,
           width: double.infinity,


### PR DESCRIPTION
### 🚀: 개요
- 지역/캘린더 + 세부 계획 파이어베이스 통합 연결

### 🚀: 작업 내용
- 지역/켈린더와 세부계획 파이어베이스 연결
- 세부 일정 저장 버튼 활성화
- 로그인 유저 초기화

### 📸: 실행 화면
### 📸: 실행 화면


### 🚀: 조정 파일
- district_setting_page.dart
- auth_view_model.dart
- schedule_page.dart
- calendar_location_repository.dart
- calendar_location_view_model.dart

### 개발 결과
- 지역/켈린더와 세부계획 파이어베이스 연결
- 세부 일정 저장 버튼 활성화
- 로그인 유저 초기화
- planId 전달 경로 구현
- userId를 calendar_location 페이지에 구독하여 다음페이지로 전달

### issue
Closes #102 
