### PR TITLE
[Plan] 사용자 선택 지역 기반 검색 필터링

### DIFF
--- a/lib/providers/search_provider.dart
+++ b/lib/providers/search_provider.dart
@@ -1,9 +1,12 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travel_muse_app/providers/neardy_place_service_provider.dart';
 import 'package:travel_muse_app/providers/place_search_service_provider.dart';
 import 'package:travel_muse_app/viewmodels/search_view_model.dart';
 
 final searchViewModelProvider =
     StateNotifierProvider<SearchViewModel, List<Map<String, String>>>((ref) {
-  final svc = ref.watch(placeSearchServiceProvider);  
-  return SearchViewModel(svc);
+  final placeSvc = ref.watch(placeSearchServiceProvider);
+  final nearbySvc = ref.watch(nearbyPlaceServiceProvider);
+  return SearchViewModel(placeSvc, nearbySvc);
 });
+

--- a/lib/services/place_search_service.dart
+++ b/lib/services/place_search_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:http/http.dart' as http;
 import 'package:travel_muse_app/models/place.dart';
 
@@ -78,4 +79,21 @@ class PlaceSearchService {
     if (url != null) _thumbCache[keyword] = url;
     return url;
   }
+
+  // 지역명을 좌표로 변환하는 메서드
+Future<LatLng?> getLatLngFromRegion(String region) async {
+  final url = Uri.parse(
+    'https://dapi.kakao.com/v2/local/search/address.json?query=$region',
+  );
+  final res = await http.get(url, headers: {'Authorization': _apiKey});
+  if (res.statusCode != 200) return null;
+
+  final docs = json.decode(res.body)['documents'] as List<dynamic>;
+  if (docs.isEmpty) return null;
+
+  final lat = double.tryParse(docs[0]['y']) ?? 0;
+  final lng = double.tryParse(docs[0]['x']) ?? 0;
+  return LatLng(lat, lng);
+}
+
 }

--- a/lib/viewmodels/search_view_model.dart
+++ b/lib/viewmodels/search_view_model.dart
@@ -1,33 +1,70 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/models/place.dart';
+import 'package:travel_muse_app/services/nearby_place_service.dart';
 import 'package:travel_muse_app/services/place_search_service.dart';
 
 class SearchViewModel extends StateNotifier<List<Map<String, String>>> {
-  SearchViewModel(this._service) : super([]);
-  final PlaceSearchService _service;
+  SearchViewModel(this._placeService, this._nearbyService) : super([]);
 
+  final PlaceSearchService _placeService;
+  final NearbyPlaceService _nearbyService;
 
- Future<void> search(String query) async {
-  try {
-    final List<Place> places = await _service.search(query);
+  static const defaultImage =
+      'https://cdn.pixabay.com/photo/2017/06/24/04/37/cloud-2436676_1280.jpg';
 
-    final List<Map<String, String>> results = [];
-
-    for (final place in places) {
-      final imageUrl = await _service.fetchImageThumbnail(place.name); // 이미지 검색 호출
-      results.add({
-        'title': place.name,
-        'subtitle': '${place.city} ${place.district} • ${place.category}',
-        'image': imageUrl ?? 'https://cdn.pixabay.com/photo/2017/06/24/04/37/cloud-2436676_1280.jpg', // 기본 이미지 대체
-        'lat' : place.latitude.toString(), //위도
-        'lng' : place.longitude.toString() //경도
-      });
+  /// 키워드 검색 (선택적으로 지역 필터 적용)
+  Future<void> search(String query, {String? region}) async {
+    try {
+      final places = await _fetchPlaces(query: query, region: region);
+      final results = await _mapPlacesToViewData(places);
+      state = results;
+    } catch (_) {
+      state = [];
     }
-
-    state = results;
-  } catch (e) {
-    state = [];
   }
-}
 
+  ///추천 명소 맛집 로드 (지역 기반)
+  Future<void> loadRecommendedByRegion(String region) async {
+    final latLng = await _placeService.getLatLngFromRegion(region);
+    if (latLng == null) return;
+
+    final spots = await _nearbyService.fetchSpots(loc: latLng);
+    final foods = await _nearbyService.fetchFoods(loc: latLng);
+    final combined = await _mapPlacesToViewData([...spots, ...foods]);
+
+    state = combined;
+  }
+
+  ///지역 기반 또는 전국 검색 처리
+  Future<List<Place>> _fetchPlaces({
+    required String query,
+    String? region,
+  }) async {
+    if (region != null) {
+      final latLng = await _placeService.getLatLngFromRegion(region);
+      if (latLng != null) {
+        return await _placeService.searchByKeyword(
+          query: query,
+          lat: latLng.latitude,
+          lng: latLng.longitude,
+        );
+      }
+    }
+    return await _placeService.search(query);
+  }
+
+  /// Place -> Map<String, String> 형태로 변환
+  Future<List<Map<String, String>>> _mapPlacesToViewData(
+      List<Place> places) async {
+    return Future.wait(places.map((p) async {
+      final thumb = await _placeService.getThumbnailCached(p.name);
+      return {
+        'title': p.name,
+        'subtitle': '${p.city} ${p.district} • ${p.category}',
+        'image': thumb ?? defaultImage,
+        'lat': p.latitude.toString(),
+        'lng': p.longitude.toString(),
+      };
+    }));
+  }
 }

--- a/lib/views/plan/place_search/place_search_page.dart
+++ b/lib/views/plan/place_search/place_search_page.dart
@@ -111,7 +111,6 @@ class _PlaceSearchPageState extends ConsumerState<PlaceSearchPage> {
                 onSubmitted: _performSearch,
               ),
             ),
-            SizedBox(height: 16),
             // 최근 검색어
             RecentSearchSection(
               onSelect: (word) {
@@ -121,7 +120,7 @@ class _PlaceSearchPageState extends ConsumerState<PlaceSearchPage> {
             ),
             if (_showInitialMessage)
               Padding(
-                padding: const EdgeInsets.only(left: 16),
+                padding: const EdgeInsets.only(left: 16, top: 10),
                 child: Row(
                   children: [
                      Padding(

--- a/lib/views/plan/schedule/schedule_page.dart
+++ b/lib/views/plan/schedule/schedule_page.dart
@@ -54,7 +54,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
   Future<void> _addPlace(int dayIndex) async {
     final selectedPlaces = await Navigator.push<List<Map<String, String>>>(
       context,
-      MaterialPageRoute(builder: (_) => PlaceSearchPage(planId: widget.planId)),
+      MaterialPageRoute(builder: (_) => PlaceSearchPage(planId: widget.planId, region: selectedPlan?.region ?? '',)),
     );
 
     if (selectedPlaces != null && selectedPlaces.isNotEmpty) {


### PR DESCRIPTION
### 🚀: 개요
- 기존 검색 기능에 지역 기반 추천 기능을 추가

### 🚀: 작업 내용
- getLatLngFromRegion() 추가
- 지역 기반 추천/검색 ViewModel 구성
- 검색 페이지 진입 시 추천 명소 & 맛집 표시
- 일정 편집 페이지에서 Plan 지역 전달

### 📸: 실행 화면
![Screenshot_1749806213](https://github.com/user-attachments/assets/66f3a450-370f-42e2-9189-31bb62211f9e)

### 🚀: 조정 파일
-place_search_page.dart
-schedule_page.dart
-search_view_model.dart
-place_search_service.dart
-search_provider.dart

### 개발 결과
- 지역 기반 추천 장소 및 맛집이 검색 페이지 진입 시 자동으로 노출됨
- 검색 시 해당 지역 내 결과만 필터링되도록 개선됨
- Plan 페이지와의 연결을 통해 자연스러운 지역 검색 흐름 구현

### issue
Closes #109 
