### PR TITLE
[Home] 홈 상단 여행날짜 d-day UX조정

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/date_symbol_data_http_request.dart';
+import 'package:intl/date_symbol_data_local.dart';
 import 'package:travel_muse_app/firebase_options.dart';
 import 'package:travel_muse_app/views/splash/splash_page.dart';
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/date_symbol_data_http_request.dart';
 import 'package:travel_muse_app/firebase_options.dart';
 import 'package:travel_muse_app/views/splash/splash_page.dart';
 
@@ -11,6 +12,7 @@ void main() async {
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   await dotenv.load(fileName: '.env');
   runApp(const ProviderScope(child: MyApp()));
+  await initializeDateFormatting('ko', '');
 }
 
 class MyApp extends StatelessWidget {

--- a/lib/repositories/calendar_location_repository.dart
+++ b/lib/repositories/calendar_location_repository.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:travel_muse_app/viewmodels/calendar_location_view_model.dart';
 
 class CalendarLocationRepository {
   CalendarLocationRepository({FirebaseFirestore? firestore})
@@ -44,5 +45,31 @@ class CalendarLocationRepository {
     });
 
     return planId;
+  }
+
+  Future<PlanState?> fetchNearestUpcomingPlan(String userId) async {
+    final now = DateTime.now();
+
+    final querySnapshot =
+        await FirebaseFirestore.instance
+            .collection('plans')
+            .where('userId', isEqualTo: userId)
+            .where('startDate', isGreaterThanOrEqualTo: Timestamp.fromDate(now))
+            .orderBy('startDate')
+            .limit(1)
+            .get();
+
+    if (querySnapshot.docs.isEmpty) {
+      return null;
+    }
+
+    final doc = querySnapshot.docs.first;
+    final data = doc.data();
+
+    return PlanState(
+      startDate: (data['startDate'] as Timestamp).toDate(),
+      endDate: (data['endDate'] as Timestamp).toDate(),
+      region: data['region'] as String,
+    );
   }
 }

--- a/lib/viewmodels/calendar_location_view_model.dart
+++ b/lib/viewmodels/calendar_location_view_model.dart
@@ -80,4 +80,16 @@ class CalendarLocationViewModel extends StateNotifier<PlanState> {
   void setDateRange(DateTime start, DateTime end) {
     state = state.copyWith(startDate: start, endDate: end);
   }
+
+  Future<void> loadNearestUpcomingPlan() async {
+    final userId = ref.read(authViewModelProvider).user?.uid;
+    if (userId == null) return;
+
+    final repo = ref.read(calendarLocationRepositoryProvider);
+    final plan = await repo.fetchNearestUpcomingPlan(userId);
+
+    if (plan != null) {
+      state = plan;
+    }
+  }
 }

--- a/lib/viewmodels/calendar_location_view_model.dart
+++ b/lib/viewmodels/calendar_location_view_model.dart
@@ -3,13 +3,20 @@ import 'package:travel_muse_app/providers/calendar_location_provider.dart';
 import 'package:travel_muse_app/viewmodels/auth_view_model.dart';
 
 class PlanState {
-  PlanState({this.startDate, this.endDate, this.region});
+  PlanState({this.planId, this.startDate, this.endDate, this.region});
+  final String? planId;
   final DateTime? startDate;
   final DateTime? endDate;
   final String? region;
 
-  PlanState copyWith({DateTime? startDate, DateTime? endDate, String? region}) {
+  PlanState copyWith({
+    String? planId,
+    DateTime? startDate,
+    DateTime? endDate,
+    String? region,
+  }) {
     return PlanState(
+      planId: planId ?? this.planId,
       startDate: startDate ?? this.startDate,
       endDate: endDate ?? this.endDate,
       region: region ?? this.region,
@@ -53,6 +60,9 @@ class CalendarLocationViewModel extends StateNotifier<PlanState> {
       region: region,
       userId: userId,
     );
+
+    // 상태에 planId 업데이트 (필요 시)
+    state = state.copyWith(planId: planId);
   }
 
   /// 내부에서 자동 planId 생성 후 저장
@@ -73,6 +83,9 @@ class CalendarLocationViewModel extends StateNotifier<PlanState> {
       region: region,
       userId: userId,
     );
+
+    // 생성된 planId를 상태에 저장
+    state = state.copyWith(planId: planId);
 
     return planId;
   }

--- a/lib/views/home/widgets/info_banner.dart
+++ b/lib/views/home/widgets/info_banner.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:travel_muse_app/providers/calendar_location_provider.dart';
+import 'package:travel_muse_app/viewmodels/auth_view_model.dart';
+import 'package:travel_muse_app/views/plan/schedule/schedule_page.dart';
 
 class InfoBanner extends ConsumerWidget {
   const InfoBanner({super.key});
@@ -9,7 +11,10 @@ class InfoBanner extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final planState = ref.watch(calendarLocationViewModelProvider);
-    final viewModel = ref.read(calendarLocationViewModelProvider.notifier);
+    final userId = ref.watch(authViewModelProvider).user?.uid;
+    final planId = ref.watch(
+      calendarLocationViewModelProvider.select((state) => state.planId),
+    );
 
     final start = planState.startDate;
     final end = planState.endDate;
@@ -103,7 +108,26 @@ class InfoBanner extends ConsumerWidget {
           ),
           TextButton(
             onPressed: () {
-              // TODO: 상세보기 이동 로직 연결
+              if (userId == null) {
+                ScaffoldMessenger.of(
+                  context,
+                ).showSnackBar(const SnackBar(content: Text('로그인 정보가 없습니다.')));
+                return;
+              }
+
+              if (planId == null) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('유효한 계획 ID가 없습니다.')),
+                );
+                return;
+              }
+
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => SchedulePage(userId: userId, planId: planId),
+                ),
+              );
             },
             style: TextButton.styleFrom(padding: EdgeInsets.zero),
             child: const Text(

--- a/lib/views/home/widgets/info_banner.dart
+++ b/lib/views/home/widgets/info_banner.dart
@@ -15,24 +15,46 @@ class InfoBanner extends ConsumerWidget {
     final end = planState.endDate;
     final region = planState.region;
 
-    // 여행까지 남은 날짜 계산
+    /// 여행까지 남은 날짜 계산
     String calculateRemainingDays(DateTime startDate) {
       final now = DateTime.now();
-      final diff = startDate.difference(now).inDays;
-      return diff > 0 ? '$diff일 남았어요!' : '여행 중이에요!';
+      final nowDate = DateTime(now.year, now.month, now.day);
+      final startDateOnly = DateTime(
+        startDate.year,
+        startDate.month,
+        startDate.day,
+      );
+
+      final diff = startDateOnly.difference(nowDate).inDays;
+
+      if (diff > 0) {
+        return '$diff일 남았어요!';
+      } else if (diff == 0) {
+        return '오늘부터 여행이에요!';
+      } else {
+        return '여행 중이에요!';
+      }
     }
 
-    // 날짜 포맷
     String formatDate(DateTime date) {
       final formatter = DateFormat('M.d (E)', 'ko');
       return formatter.format(date);
     }
 
-    // 여행 정보가 없을 경우
-    if (start == null || end == null || region == null) {
-      // 최초 1회 자동 불러오기
-      viewModel.loadNearestUpcomingPlan();
+    String getMainRegion(String region) {
+      return region.split(' ').first;
+    }
 
+    /// 여행 종료 여부 확인
+    bool isTripFinished(DateTime endDate) {
+      final now = DateTime.now();
+      final today = DateTime(now.year, now.month, now.day);
+      final tripEnd = DateTime(endDate.year, endDate.month, endDate.day);
+      return tripEnd.isBefore(today);
+    }
+
+    /// 여행 정보가 없거나 지난 여행만 있을 경우
+    if (start == null || end == null || region == null || isTripFinished(end)) {
       return const Padding(
         padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         child: Align(
@@ -58,7 +80,7 @@ class InfoBanner extends ConsumerWidget {
           Align(
             alignment: Alignment.centerLeft,
             child: Text(
-              '사용자님,\n$region 여행까지 ${calculateRemainingDays(start)}',
+              '사용자님,\n${calculateRemainingDays(start) == '여행 중이에요!' || calculateRemainingDays(start) == '오늘부터 여행이에요!' ? '${getMainRegion(region)} ${calculateRemainingDays(start)}' : '${getMainRegion(region)} 여행까지 ${calculateRemainingDays(start)}'}',
               style: const TextStyle(
                 fontSize: 24,
                 fontWeight: FontWeight.w700,

--- a/lib/views/home/widgets/info_banner.dart
+++ b/lib/views/home/widgets/info_banner.dart
@@ -98,7 +98,7 @@ class InfoBanner extends ConsumerWidget {
           Align(
             alignment: Alignment.centerLeft,
             child: Text(
-              '${end.difference(start).inDays + 1}박 ${end.difference(start).inDays + 2}일 | ${formatDate(start)} - ${formatDate(end)}',
+              '${end.difference(start).inDays}박 ${end.difference(start).inDays + 1}일 | ${formatDate(start)} - ${formatDate(end)}',
               style: const TextStyle(
                 fontSize: 14,
                 color: Color(0xFF7C878C),

--- a/lib/views/home/widgets/info_banner.dart
+++ b/lib/views/home/widgets/info_banner.dart
@@ -1,20 +1,65 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:intl/intl.dart';
+import 'package:travel_muse_app/providers/calendar_location_provider.dart';
 
-class InfoBanner extends StatelessWidget {
+class InfoBanner extends ConsumerWidget {
   const InfoBanner({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final planState = ref.watch(calendarLocationViewModelProvider);
+    final viewModel = ref.read(calendarLocationViewModelProvider.notifier);
+
+    final start = planState.startDate;
+    final end = planState.endDate;
+    final region = planState.region;
+
+    // 여행까지 남은 날짜 계산
+    String calculateRemainingDays(DateTime startDate) {
+      final now = DateTime.now();
+      final diff = startDate.difference(now).inDays;
+      return diff > 0 ? '$diff일 남았어요!' : '여행 중이에요!';
+    }
+
+    // 날짜 포맷
+    String formatDate(DateTime date) {
+      final formatter = DateFormat('M.d (E)', 'ko');
+      return formatter.format(date);
+    }
+
+    // 여행 정보가 없을 경우
+    if (start == null || end == null || region == null) {
+      // 최초 1회 자동 불러오기
+      viewModel.loadNearestUpcomingPlan();
+
+      return const Padding(
+        padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        child: Align(
+          alignment: Alignment.centerLeft,
+          child: Text(
+            '예정된 여행이 없습니다.',
+            style: TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.w700,
+              color: Color(0xFF26272A),
+              height: 1.5,
+            ),
+          ),
+        ),
+      );
+    }
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.end,
         children: [
-          const Align(
+          Align(
             alignment: Alignment.centerLeft,
             child: Text(
-              '사용자님,\n도쿄 여행까지 3일 남았어요!',
-              style: TextStyle(
+              '사용자님,\n$region 여행까지 ${calculateRemainingDays(start)}',
+              style: const TextStyle(
                 fontSize: 24,
                 fontWeight: FontWeight.w700,
                 color: Color(0xFF26272A),
@@ -23,11 +68,11 @@ class InfoBanner extends StatelessWidget {
             ),
           ),
           const SizedBox(height: 4),
-          const Align(
+          Align(
             alignment: Alignment.centerLeft,
             child: Text(
-              '6박 7일 | 6.4 (수) - 6.11 (수)',
-              style: TextStyle(
+              '${end.difference(start).inDays + 1}박 ${end.difference(start).inDays + 2}일 | ${formatDate(start)} - ${formatDate(end)}',
+              style: const TextStyle(
                 fontSize: 14,
                 color: Color(0xFF7C878C),
                 fontWeight: FontWeight.w400,


### PR DESCRIPTION
### 🚀: 개요
- 홈 상단 여행날짜 d-day UX조정

### 🚀: 작업 내용
- 홈 상단 여행날짜 d-day 연결
- 자세히 보기 활성화 

### 📸: 실행 화면
### 📸: 실행 화면
<img width="305" alt="스크린샷 2025-06-16 오전 10 39 47" src="https://github.com/user-attachments/assets/f90cb3c1-110b-4bbb-b3e6-b40925b51062" />
<img width="309" alt="스크린샷 2025-06-16 오전 10 41 27" src="https://github.com/user-attachments/assets/27cbada5-4327-48d7-92c2-05d6aa8fb072" />


### 🚀: 조정 파일
- calendar_location_view_model.dart
- info_banner.dart

### 개발 결과
- 홈 상단 여행날짜 d-day 연결
- 자세히 보기 활성화 
- planstate planid 추가
- 박/일 계산 수정
- 출력 멘트 세분화 

### issue
Closes #123 
