### PR TITLE
[Etc] 홈,일정 페이지 및 기타 UX조정

### DIFF
--- a/lib/views/home/widgets/travel_register_button.dart
+++ b/lib/views/home/widgets/travel_register_button.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/core/widgets/svg_icon.dart';
 import 'package:travel_muse_app/views/calendar/calendar_page.dart';
-import 'package:travel_muse_app/views/plan/schedule/schedule_page.dart';
+import 'package:travel_muse_app/views/my_page/plan_list_page.dart';
 
 class TravelRegisterButton extends StatelessWidget {
   const TravelRegisterButton({super.key});
@@ -10,50 +10,56 @@ class TravelRegisterButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Row(
       children: [
-        // 일정 변경 카드
-        Expanded(
-          child: Container(
-            height: 101,
-            margin: const EdgeInsets.only(right: 8),
-            padding: const EdgeInsets.all(16),
-            decoration: BoxDecoration(
-              color: Colors.white,
-              border: Border.all(color: const Color(0xFFB3B9BC)),
-              borderRadius: BorderRadius.circular(10),
-            ),
-            child: Stack(
-              children: [
-                const Align(
-                  alignment: Alignment.topRight,
-                  child: Text(
-                    '여행 일정\n변경',
-                    textAlign: TextAlign.right,
-                    style: TextStyle(
-                      fontSize: 22,
-                      fontWeight: FontWeight.w600,
-                      color: Color(0xFF4C5356),
-                      height: 1.1,
-                    ),
-                  ),
-                ),
-                Positioned(
-                  left: 0,
-                  bottom: 0,
-                  child: SvgIcon.edit(width: 36, height: 36),
-                ),
-              ],
-            ),
-          ),
-        ),
-
         Expanded(
           child: GestureDetector(
             onTap: () {
               Navigator.push(
                 context,
-                MaterialPageRoute(
-                  builder: (_) => const CalendarPage(),
-                ), // userId: 'test-user', planId: 'test'
+                MaterialPageRoute(builder: (_) => const PlanListPage()),
+              );
+            },
+            child: Container(
+              height: 101,
+              margin: const EdgeInsets.only(right: 8),
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: Colors.white,
+                border: Border.all(color: const Color(0xFFB3B9BC)),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Stack(
+                children: [
+                  const Align(
+                    alignment: Alignment.topRight,
+                    child: Text(
+                      '여행 일정\n변경',
+                      textAlign: TextAlign.right,
+                      style: TextStyle(
+                        fontSize: 22,
+                        fontWeight: FontWeight.w600,
+                        color: Color(0xFF4C5356),
+                        height: 1.1,
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    left: 0,
+                    bottom: 0,
+                    child: SvgIcon.edit(width: 36, height: 36),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+
+        // 여행 일정 등록 버튼
+        Expanded(
+          child: GestureDetector(
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const CalendarPage()),
               );
             },
             child: Container(

--- a/lib/views/plan/schedule/widgets/schedule_bottom_button.dart
+++ b/lib/views/plan/schedule/widgets/schedule_bottom_button.dart
@@ -26,7 +26,7 @@ class ScheduleBottomButtons extends StatelessWidget {
             borderRadius: BorderRadius.circular(10),
           ),
           child: const Text(
-            '일정 수정하기',
+            '일정 저장하기',
             style: TextStyle(
               color: Colors.white,
               fontSize: 16,

--- a/lib/views/plan/widgets/schedule_app_bar.dart
+++ b/lib/views/plan/widgets/schedule_app_bar.dart
@@ -10,17 +10,14 @@ class ScheduleAppBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     return AppBar(
-      leading: IconButton(
-        icon: const Icon(Icons.chevron_left),
-        onPressed: () => Navigator.of(context).pop(),
-      ),
-      title:  Text(
+      automaticallyImplyLeading: false,
+      title: Text(
         '여행 일정 등록',
         style: TextStyle(
           color: AppColors.grey[800],
           fontSize: 18,
           fontFamily: 'Pretendard',
-          fontWeight: FontWeight.w700
+          fontWeight: FontWeight.w700,
         ),
       ),
       centerTitle: true,
@@ -44,4 +41,3 @@ class ScheduleAppBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
 }
-


### PR DESCRIPTION
### 🚀: 개요
- 홈,일정 페이지 및 기타 UX조정

### 🚀: 작업 내용
- 홈 일정변경 버튼 활성화
- 스케줄 저장 버튼 텍스트 수정
- 스케줄 페이지 뒤로가기 버튼 삭제

### 📸: 실행 화면
### 📸: 실행 화면

### 🚀: 조정 파일
- home_page.dart
- schedule_page.dart
- schedule_appbar.dart

### 개발 결과
- 홈 일정변경 버튼 활성화
- 스케줄 저장 버튼 텍스트 수정
- 스케줄 페이지 뒤로가기 버튼 삭제

### issue
Closes #128 
