### PR TITLE
[Etc] 바텀바 개선 및 기타 UX 조정

### DIFF
--- a/lib/core/widgets/bottom_bar.dart
+++ b/lib/core/widgets/bottom_bar.dart
@@ -69,7 +69,7 @@ class BottomBar extends ConsumerWidget {
               behavior: HitTestBehavior.opaque,
               child: Container(
                 height: 100,
-                padding: const EdgeInsets.only(top: 10), // 아이콘과 텍스트 위로 이동
+                padding: const EdgeInsets.only(top: 10),
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.start,
                   children: [

--- a/lib/core/widgets/bottom_bar.dart
+++ b/lib/core/widgets/bottom_bar.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/providers/bottom_bar_provider.dart';
-import 'package:travel_muse_app/views/home/home_page.dart';
 import 'package:travel_muse_app/views/home/recommended_place/recommended_places_list_page.dart';
 import 'package:travel_muse_app/views/my_page/my_page.dart';
 import 'package:travel_muse_app/views/my_page/plan_list_page.dart';
@@ -22,8 +21,8 @@ class BottomBar extends ConsumerWidget {
       Widget page;
       switch (index) {
         case 0:
-          page = const HomePage();
-          break;
+          Navigator.of(context).popUntil((route) => route.isFirst);
+          return;
         case 1:
           page = const PlanListPage();
           break;
@@ -37,9 +36,10 @@ class BottomBar extends ConsumerWidget {
           return;
       }
 
-      Navigator.pushReplacement(
-        context,
+      // 홈만 남기고 새 페이지 push
+      Navigator.of(context).pushAndRemoveUntil(
         MaterialPageRoute(builder: (context) => page),
+        (route) => route.isFirst,
       );
     }
 
@@ -69,7 +69,7 @@ class BottomBar extends ConsumerWidget {
               behavior: HitTestBehavior.opaque,
               child: Container(
                 height: 100,
-                padding: const EdgeInsets.only(top: 10),
+                padding: const EdgeInsets.only(top: 10), // 아이콘과 텍스트 위로 이동
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.start,
                   children: [

--- a/lib/core/widgets/bottom_bar.dart
+++ b/lib/core/widgets/bottom_bar.dart
@@ -52,7 +52,7 @@ class BottomBar extends ConsumerWidget {
 
     return Container(
       width: double.infinity,
-      height: 56,
+      height: 100,
       decoration: BoxDecoration(
         color: Colors.white,
         border: Border(
@@ -68,9 +68,10 @@ class BottomBar extends ConsumerWidget {
               onTap: () => _onItemTapped(index),
               behavior: HitTestBehavior.opaque,
               child: Container(
-                height: 56,
+                height: 100,
+                padding: const EdgeInsets.only(top: 10),
                 child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisAlignment: MainAxisAlignment.start,
                   children: [
                     Icon(
                       items[index]['icon'] as IconData,

--- a/lib/views/plan/location_setting/widgets/district_box_item.dart
+++ b/lib/views/plan/location_setting/widgets/district_box_item.dart
@@ -32,8 +32,12 @@ class DistrictBoxItem extends StatelessWidget {
         ),
         child: Text(
           text,
+          textAlign: TextAlign.center,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          softWrap: true,
           style: TextStyle(
-            fontSize: 16,
+            fontSize: text == '세종특별자치시' ? 13 : 16,
             fontWeight: FontWeight.bold,
             color: isSelected ? Colors.white : Colors.black,
           ),

--- a/lib/views/plan/schedule/schedule_page.dart
+++ b/lib/views/plan/schedule/schedule_page.dart
@@ -4,6 +4,7 @@ import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/models/plans.dart';
 import 'package:travel_muse_app/providers/schedule_provider.dart';
 import 'package:travel_muse_app/utills/date_utils.dart';
+import 'package:travel_muse_app/views/home/home_page.dart';
 import 'package:travel_muse_app/views/plan/place_search/place_search_page.dart';
 import 'package:travel_muse_app/views/plan/schedule/widgets/ai_button.dart';
 import 'package:travel_muse_app/views/plan/schedule/widgets/day_schedule_section.dart';
@@ -54,7 +55,13 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
   Future<void> _addPlace(int dayIndex) async {
     final selectedPlaces = await Navigator.push<List<Map<String, String>>>(
       context,
-      MaterialPageRoute(builder: (_) => PlaceSearchPage(planId: widget.planId, region: selectedPlan?.region ?? '',)),
+      MaterialPageRoute(
+        builder:
+            (_) => PlaceSearchPage(
+              planId: widget.planId,
+              region: selectedPlan?.region ?? '',
+            ),
+      ),
     );
 
     if (selectedPlaces != null && selectedPlaces.isNotEmpty) {
@@ -209,6 +216,11 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
           ScaffoldMessenger.of(
             context,
           ).showSnackBar(const SnackBar(content: Text('일정이 저장되었습니다.')));
+
+          await Navigator.pushReplacement(
+            context,
+            MaterialPageRoute(builder: (context) => HomePage()),
+          );
         },
       ),
     );

--- a/lib/views/plan/widgets/schedule_app_bar.dart
+++ b/lib/views/plan/widgets/schedule_app_bar.dart
@@ -10,7 +10,10 @@ class ScheduleAppBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     return AppBar(
-      automaticallyImplyLeading: false,
+      leading: IconButton(
+        icon: const Icon(Icons.chevron_left),
+        onPressed: () => Navigator.of(context).pop(),
+      ),
       title: Text(
         '여행 일정 등록',
         style: TextStyle(


### PR DESCRIPTION
### 🚀: 개요
- 바텀바 개선 및 기타 UX 조정

### 🚀: 작업 내용
- 바텀바 개선
- 기타 UX 개선

### 📸: 실행 화면
### 📸: 실행 화면
<img width="308" alt="스크린샷 2025-06-17 오전 1 54 26" src="https://github.com/user-attachments/assets/ee4a4807-bb35-4725-9ece-2f017a845494" />


### 🚀: 조정 파일
- bottom_bar.dart
- schedule_page.dart
- district_setting_page.dart  

### 개발 결과
- 바텀바 스택 조정
- 바텀바 UI 조정
- 세종시 버튼 디자인 조정
- 저장 버튼 누를시 홈으로 이동

### issue
Closes #132 
