### PR TITLE
[Location] 지도 페이지 전체 루트 시각화 

### DIFF
--- a/lib/models/home/home_place.dart
+++ b/lib/models/home/home_place.dart
@@ -39,6 +39,24 @@ class HomePlace {
       distance: distance,
     );
   }
+
+  factory HomePlace.fromMap(Map<String, dynamic> map) {
+    return HomePlace(
+      id: map['id'] ?? '',
+      title: map['title'] ?? '',
+      subtitle: map['subtitle'] ?? '',
+      thumbnail: map['image'] ?? '', 
+      latLng: LatLng(
+        double.tryParse(map['lat']?.toString() ?? '0') ?? 0,
+        double.tryParse(map['lng']?.toString() ?? '0') ?? 0,
+      ),
+      category: map['category'] ?? '',
+      phone: map['phone'],
+      placeUrl: map['placeUrl'],
+      isFavorite: map['isFavorite'] ?? false,
+      distance: map['distance'],
+    );
+  }
 }
 
 extension PlaceMapping on Place {

--- a/lib/viewmodels/plan/map_view_model.dart
+++ b/lib/viewmodels/plan/map_view_model.dart
@@ -131,4 +131,30 @@ class MapViewModel extends StateNotifier<MapState> {
           ),
     );
   }
+
+  /// 전체 날짜의 모든 장소 리스트를 반환합니다.
+  List<Map<String, dynamic>> getAllPlaces() {
+    return state.dayPlaces.values.expand((list) => list).toList();
+  }
+
+  ///전체 위경도 반환
+  List<LatLng> getAllLatLngs() {
+    return extractLatLngs(getAllPlaces());
+  }
+
+//전체 마커 반환
+  Set<Marker> getAllMarkers({
+    required Function(Map<String, dynamic>) onTap,
+    required Function(int) onPageChanged,
+  }) {
+    return createMarkers(
+      places: getAllPlaces(),
+      icon: _currentIcon,
+      onTap: onTap,
+      onPageChanged: onPageChanged,
+      animateToPage: (idx) {
+        // 전체 탭은 Carousel 안 보이게 할 수도 있음
+      },
+    );
+  }
 }

--- a/lib/views/plan/location/map_page.dart
+++ b/lib/views/plan/location/map_page.dart
@@ -36,15 +36,23 @@ class _MapPageState extends ConsumerState<MapPage>
 
     if (!_tabController!.indexIsChanging) {
       setState(() {});
-      final newPlaces =
-          mapState.dayPlaces[dayKeys[_tabController!.index]] ?? [];
-      _viewModel.moveCameraToFitAll(_mapController, newPlaces);
+
+      final index = _tabController!.index;
+
+      if (index == 0) {
+        final allPlaces = _viewModel.getAllPlaces();
+        _viewModel.moveCameraToFitAll(_mapController, allPlaces);
+      } else {
+        final newPlaces =
+            mapState.dayPlaces[dayKeys[_tabController!.index - 1]] ?? [];
+        _viewModel.moveCameraToFitAll(_mapController, newPlaces);
+      }
     }
   }
 
   bool _isLoading(TabController? tabController, List<String> dayKeys) {
     if (tabController == null || dayKeys.isEmpty) return true;
-    if (tabController.index >= dayKeys.length) return true;
+    if (tabController.index >= dayKeys.length + 1) return true;
     return false;
   }
 
@@ -55,7 +63,7 @@ class _MapPageState extends ConsumerState<MapPage>
     final dayKeys = ref.read(mapViewModelProvider).dayPlaces.keys.toList();
     if (dayKeys.isEmpty) return;
 
-    _tabController = TabController(length: dayKeys.length, vsync: this);
+    _tabController = TabController(length: dayKeys.length + 1, vsync: this);
     _tabController!.addListener(_onTabChanged);
 
     setState(() {});
@@ -102,15 +110,19 @@ class _MapPageState extends ConsumerState<MapPage>
     }
 
     final index = _tabController!.index;
-    final selectedDayKey = dayKeys[index];
-    final selectedPlaces = mapState.dayPlaces[selectedDayKey] ?? [];
+    List<Map<String, dynamic>> selectedPlaces;
+    if (index == 0) {
+      selectedPlaces = _viewModel.getAllPlaces(); 
+    } else {
+      selectedPlaces = mapState.dayPlaces[dayKeys[index - 1]] ?? [];
+    }
 
     _initCameraPosition(selectedPlaces);
 
     final points = _viewModel.extractLatLngs(selectedPlaces);
     final markers = _viewModel.getMarkers(
       places: selectedPlaces,
-      selectedDayKey: selectedDayKey,
+      selectedDayKey: index == 0 ? 'all' : dayKeys[index - 1],
       onTap: (place) => _viewModel.selectPlace(place),
       onPageChanged: (index) {
         if (!_tabController!.indexIsChanging) {
@@ -118,7 +130,7 @@ class _MapPageState extends ConsumerState<MapPage>
         }
       },
     );
-    final displayDayTabs = dayKeys.map(getDisplayDayTab).toList();
+    final displayDayTabs = ['All', ...dayKeys.map(getDisplayDayTab)];
     return Scaffold(
       appBar: MapPageAppBar(),
       body: Column(
@@ -162,7 +174,7 @@ class _MapPageState extends ConsumerState<MapPage>
           ),
         ],
       ),
-              bottomNavigationBar: const BottomBar(),
+      bottomNavigationBar: const BottomBar(),
     );
   }
 }

--- a/lib/views/plan/location/widgets/place_card.dart
+++ b/lib/views/plan/location/widgets/place_card.dart
@@ -10,7 +10,7 @@ class PlaceCard extends StatelessWidget {
     super.key,
   });
 
-  final Map<String, String> placeData;
+  final Map<String, dynamic> placeData;
   final bool isSelected;
   final VoidCallback? onTap;
 

--- a/lib/views/plan/location/widgets/place_carousel.dart
+++ b/lib/views/plan/location/widgets/place_carousel.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:travel_muse_app/models/home/home_place.dart';
 import 'package:travel_muse_app/models/plan/map_state.dart';
 import 'package:travel_muse_app/utills/latlng_helper.dart';
 import 'package:travel_muse_app/viewmodels/plan/map_view_model.dart';
+import 'package:travel_muse_app/views/home/recommended_place/recommended_place_detail_page.dart';
 import 'package:travel_muse_app/views/plan/location/widgets/place_card.dart';
 
 class PlaceCarousel extends StatelessWidget {
@@ -25,41 +27,88 @@ class PlaceCarousel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final allPlaces = viewModel.getAllPlaces();
+    final allController = viewModel.getPageController('all');
+
     return TabBarView(
       controller: tabController,
-      children:
-          dayKeys.map((day) {
-            final places = mapState.dayPlaces[day] ?? [];
-            final pageController = viewModel.getPageController(day);
-
-            return PageView.builder(
-              itemCount: places.length,
-              controller: pageController,
-              onPageChanged: (index) {
-                final place = places[index];
-                final latLng = parseLatLng(place); // 헬퍼 함수 사용!
-                if (latLng != null) {
-                  mapController?.animateCamera(
-                    CameraUpdate.newLatLngZoom(latLng, 14),
-                  );
-                }
-                viewModel.selectPlace(place);
-              },
-              itemBuilder: (context, index) {
-                final place = places[index];
-                return Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 8.0,
-                    vertical: 12,
-                  ),
-                  child: PlaceCard(
-                    placeData: place,
-                    isSelected: selectedPlace?['id'] == place['id'],
-                  ),
-                );
-              },
+      children: [
+        PageView.builder(
+          itemCount: allPlaces.length,
+          controller: allController,
+          onPageChanged: (index) {
+            final place = allPlaces[index];
+            final latLng = parseLatLng(place);
+            if (latLng != null) {
+              mapController?.animateCamera(
+                CameraUpdate.newLatLngZoom(latLng, 14),
+              );
+            }
+            viewModel.selectPlace(place);
+          },
+          itemBuilder: (context, index) {
+            final place = allPlaces[index];
+            return Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: 8.0,
+                vertical: 12,
+              ),
+              child: PlaceCard(
+                placeData: place,
+                isSelected: selectedPlace?['id'] == place['id'],
+              ),
             );
-          }).toList(),
+          },
+        ),
+
+        for (final day in dayKeys)
+          Builder(
+            builder: (context) {
+              final places = mapState.dayPlaces[day] ?? [];
+              final pageController = viewModel.getPageController(day);
+
+              return PageView.builder(
+                itemCount: places.length,
+                controller: pageController,
+                onPageChanged: (index) {
+                  final place = places[index];
+                  final latLng = parseLatLng(place);
+                  if (latLng != null) {
+                    mapController?.animateCamera(
+                      CameraUpdate.newLatLngZoom(latLng, 14),
+                    );
+                  }
+                  viewModel.selectPlace(place);
+                },
+                itemBuilder: (context, index) {
+                  final place = places[index];
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8.0,
+                      vertical: 12,
+                    ),
+                    child: PlaceCard(
+                      placeData: place,
+                      isSelected: selectedPlace?['id'] == place['id'],
+                      onTap: () {
+                        final homePlace = HomePlace.fromMap(place); 
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder:
+                                (_) => RecommendedPlaceDetailPage(
+                                  place: homePlace,
+                                ),
+                          ),
+                        );
+                      },
+                    ),
+                  );
+                },
+              );
+            },
+          ),
+      ],
     );
   }
 }


### PR DESCRIPTION
### 🚀: 개요
- MapPage에 전체 일정 보여주는 탭 추가
- PlaceCard 클릭 시 추천 상세 페이지로 이동하는 기능 구현

### 🚀: 작업 내용
- 전체 일정 탭 추가
- TabController에 All 탭 고려하여 인덱스 보정 처리
- 전체 경로 기반 카메라 이동 및 마커 표시 구현
- onTap 콜백 추가 및 상세 페이지 라우팅 연동

### 📸: 실행 화면
![Screenshot_1750407543](https://github.com/user-attachments/assets/5abfe36f-49b3-40a2-89ba-bf9d59629c3c)


### 🚀: 조정 파일
- map_page.dart
- map_view_model.dart
- place_carousel.dart
- place.card.dart
- home_place.dart

### 개발 결과
- 전체 여행 일정의 루트 시각화 가능
- 장소 클릭 시 상세 정보 확인 동선 연결 완료

### issue
Closes #171 
