### PR TITLE
[Preference] 여행 성향테스트 삭제 기능 추가 

### DIFF
--- a/lib/providers/preference/preference_test_provider.dart
+++ b/lib/providers/preference/preference_test_provider.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/models/preference/preference_test_model.dart';
 import 'package:travel_muse_app/repositories/preference/preference_test_repository.dart';
@@ -14,4 +15,14 @@ final preferenceTestStreamProvider =
     StreamProvider.family<PreferenceTest, String>((ref, testId) {
       final repository = PreferenceTestRepository();
       return repository.watchTest(testId);
+    });
+
+// 전체 리스트 조회용
+final preferenceTestListProvider =
+    FutureProvider.autoDispose<List<PreferenceTest>>((ref) async {
+      final user = FirebaseAuth.instance.currentUser;
+      if (user == null) return [];
+
+      final repository = PreferenceTestRepository();
+      return await repository.fetchTestsByUserId(user.uid);
     });

--- a/lib/repositories/preference/preference_test_repository.dart
+++ b/lib/repositories/preference/preference_test_repository.dart
@@ -79,4 +79,9 @@ class PreferenceTestRepository {
         .map((doc) => PreferenceTest.fromDoc(doc.id, doc.data()))
         .toList();
   }
+
+  ///테스트Id로 삭제
+  Future<void> deleteTest(String testId) async {
+    await _firestore.collection(_collection).doc(testId).delete();
+  }
 }

--- a/lib/viewmodels/preference/preference_test_state_notifier.dart
+++ b/lib/viewmodels/preference/preference_test_state_notifier.dart
@@ -67,4 +67,15 @@ class PreferenceTestStateNotifier
       return [];
     }
   }
+
+  /// 성향 테스트 삭제
+  Future<void> deleteTest(String testId) async {
+    state = const AsyncLoading();
+    try {
+      await _repository.deleteTest(testId);
+      state = const AsyncValue.data(null); // 상태 초기화
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
 }

--- a/lib/views/my_page/preference_list_page.dart
+++ b/lib/views/my_page/preference_list_page.dart
@@ -53,8 +53,8 @@ class _PreferenceListPageState extends ConsumerState<PreferenceListPage> {
                       return MyPageListItem(
                         itemTitle: _tests[index].result['type'] ?? '알 수 없음',
                         index: index,
-                        onTap: () {
-                          Navigator.push(
+                        onTap: () async {
+                          final result = await Navigator.push(
                             context,
                             CupertinoPageRoute(
                               builder:
@@ -65,6 +65,19 @@ class _PreferenceListPageState extends ConsumerState<PreferenceListPage> {
                                   ),
                             ),
                           );
+
+                          if (result == 'deleted') {
+                            final tests =
+                                await ref
+                                    .read(
+                                      preferenceTestStateNotifierProvider
+                                          .notifier,
+                                    )
+                                    .fetchTestsByUserId();
+                            setState(() {
+                              _tests = tests;
+                            });
+                          }
                         },
                       );
                     },

--- a/lib/views/preference/widgets/result_view.dart
+++ b/lib/views/preference/widgets/result_view.dart
@@ -64,7 +64,64 @@ class _ResultViewState extends ConsumerState<ResultView> {
     }
 
     return Scaffold(
-      appBar: !widget.showButtons ? AppBar(title: Text('나의 여행 성향')) : null,
+      appBar:
+          !widget.showButtons
+              ? AppBar(
+                title: const Text('나의 여행 성향'),
+                actions: [
+                  PopupMenuButton<String>(
+                    icon: const Icon(Icons.more_vert),
+                    onSelected: (value) async {
+                      if (value == 'delete') {
+                        final confirm = await showCupertinoModalPopup<bool>(
+                          context: context,
+                          builder:
+                              (_) => CupertinoActionSheet(
+                                title: const Text('성향 테스트 삭제'),
+                                message: const Text('이 테스트 결과를 삭제하시겠어요?'),
+                                actions: [
+                                  CupertinoActionSheetAction(
+                                    isDestructiveAction: true,
+                                    onPressed: () {
+                                      Navigator.pop(context, true);
+                                    },
+                                    child: const Text('삭제하기'),
+                                  ),
+                                ],
+                                cancelButton: CupertinoActionSheetAction(
+                                  onPressed:
+                                      () => Navigator.pop(context, false),
+                                  child: const Text('취소'),
+                                ),
+                              ),
+                        );
+
+                        if (confirm == true) {
+                          await ref
+                              .read(
+                                preferenceTestStateNotifierProvider.notifier,
+                              )
+                              .deleteTest(widget.testId);
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('성향 테스트가 삭제되었습니다')),
+                            );
+                            Navigator.pop(context);
+                          }
+                        }
+                      }
+                    },
+                    itemBuilder:
+                        (_) => [
+                          const PopupMenuItem<String>(
+                            value: 'delete',
+                            child: Text('삭제'),
+                          ),
+                        ],
+                  ),
+                ],
+              )
+              : null,
       backgroundColor: AppColors.white,
       body: Stack(
         children: [

--- a/lib/views/preference/widgets/result_view.dart
+++ b/lib/views/preference/widgets/result_view.dart
@@ -70,6 +70,7 @@ class _ResultViewState extends ConsumerState<ResultView> {
                 title: const Text('나의 여행 성향'),
                 actions: [
                   PopupMenuButton<String>(
+                    color: Colors.white,
                     icon: const Icon(Icons.more_vert),
                     onSelected: (value) async {
                       if (value == 'delete') {
@@ -103,10 +104,17 @@ class _ResultViewState extends ConsumerState<ResultView> {
                               )
                               .deleteTest(widget.testId);
                           if (context.mounted) {
+                            /// 리스트 Provider invalidate
+                            ref.invalidate(preferenceTestListProvider);
+
+                            /// 단건 상태 초기화
+                            ref.invalidate(preferenceTestStateNotifierProvider);
+
                             ScaffoldMessenger.of(context).showSnackBar(
                               const SnackBar(content: Text('성향 테스트가 삭제되었습니다')),
                             );
-                            Navigator.pop(context);
+
+                            Navigator.pop(context, 'deleted');
                           }
                         }
                       }
@@ -115,7 +123,10 @@ class _ResultViewState extends ConsumerState<ResultView> {
                         (_) => [
                           const PopupMenuItem<String>(
                             value: 'delete',
-                            child: Text('삭제'),
+                            child: Text(
+                              '삭제',
+                              style: TextStyle(color: Colors.red),
+                            ),
                           ),
                         ],
                   ),


### PR DESCRIPTION
### 🚀: 개요
- 성향 테스트 삭제 기능 구현 및 리스트 화면 반영 처리

### 🚀: 작업 내용
ResultView 상단 AppBar에 삭제 메뉴 추가 (PopupMenuButton)

삭제 확인 시 Firestore에서 테스트 문서 삭제

삭제 후 Navigator.pop(context, 'deleted')로 결과 전달

PreferenceListPage에서 push 결과가 'deleted'일 경우 리스트 새로고침 처리

삭제 후 스낵바 메시지 노출

### 📸: 실행 화면
### 📸: 실행 화면
<img src="https://github.com/user-attachments/assets/1f9f2584-9f7d-4ed4-a771-4d9da7668294" width="300" />
<img src="https://github.com/user-attachments/assets/89ce5751-a524-4e62-9a3b-7fcd6862b0a8" width="300" />

### 🚀: 조정 파일
result_view.dart

preference_list_page.dart

### 개발 결과
성향 테스트 개별 삭제 기능 정상 작동

삭제 후 리스트 즉시 반영됨

사용자에게 피드백(SnackBar) 제공

### issue
Closes #157 
