### PR TITLE
[Plan] 일정 저장 방식 변경, 일정 삭제, 검색 재진입 이슈 수정

### DIFF
--- a/lib/repositories/plan/schedule_repository.dart
+++ b/lib/repositories/plan/schedule_repository.dart
@@ -187,4 +187,42 @@ class ScheduleRepository {
 
     return result;
   }
+
+  /// 전체 일정 삭제
+Future<void> deletePlanById(String planId) async {
+  final planRef = _firestore.collection('plans').doc(planId);
+
+  final routeSnapshot = await planRef.collection('route').get();
+  final aiRouteSnapshot = await planRef.collection('ai_route').get();
+
+  final batch = _firestore.batch();
+
+  // 서브컬렉션 route 삭제
+  for (var doc in routeSnapshot.docs) {
+    batch.delete(doc.reference);
+  }
+
+  // 서브컬렉션 ai_route 삭제
+  for (var doc in aiRouteSnapshot.docs) {
+    batch.delete(doc.reference);
+  }
+
+  // plan 문서 삭제
+  batch.delete(planRef);
+
+  await batch.commit();
+}
+
+/// appUser 문서에서 planId 제거
+Future<void> removePlanIdFromUser({
+  required String userId,
+  required String planId,
+}) async {
+  final userDocRef = _firestore.collection('appUser').doc(userId);
+
+  await userDocRef.update({
+    'planId': FieldValue.arrayRemove([planId]),
+  });
+}
+
 }

--- a/lib/viewmodels/plan/schedule_view_model.dart
+++ b/lib/viewmodels/plan/schedule_view_model.dart
@@ -143,4 +143,34 @@ class ScheduleViewModel extends StateNotifier<AsyncValue<ScheduleState>> {
     final snap = await _repository.fetchRoute(planId);
     return snap.isNotEmpty;
   }
+
+  /// 일정삭제
+  Future<void> deletePlanById(String planId) async {
+    if (currentUser == null) return;
+    try {
+      // DB에서 삭제
+      await _repository.deletePlanById(planId);
+
+      // appUser 문서에서 planId 제거
+      await _repository.removePlanIdFromUser(
+        userId: currentUser!.uid,
+        planId: planId,
+      );
+
+      // 상태 동기화
+      _allPlans.removeWhere((p) => p.planId == planId);
+      final updatedSavedPlans =
+          state.value!.savedPlans.where((p) => p.planId != planId).toList();
+
+      state = AsyncData(
+        state.value!.copyWith(
+          allPlans: _allPlans,
+          savedPlans: updatedSavedPlans,
+        ),
+      );
+    } catch (e, st) {
+      log('일정 삭제 실패: $e');
+      state = AsyncError(e, st);
+    }
+  }
 }

--- a/lib/views/my_page/plan_list_page.dart
+++ b/lib/views/my_page/plan_list_page.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/providers/plan/schedule/schedule_provider.dart';
@@ -19,6 +20,8 @@ class PlanListPage extends ConsumerStatefulWidget {
 }
 
 class _PlanListPageState extends ConsumerState<PlanListPage> {
+  bool _isEditMode = false;
+
   @override
   void initState() {
     super.initState();
@@ -26,6 +29,37 @@ class _PlanListPageState extends ConsumerState<PlanListPage> {
       await ref.read(profileViewModelProvider.notifier).fetchUserProfile();
       await ref.read(scheduleViewModelProvider.notifier).fetchSavedPlans();
     });
+  }
+
+  Future<void> _showDeleteDialog(String planId) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('일정 삭제'),
+        content: const Text('이 일정을 삭제하시겠습니까?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('취소'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('삭제'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm == true) {
+      await ref.read(scheduleViewModelProvider.notifier).deletePlanById(planId);
+      await ref.read(scheduleViewModelProvider.notifier).fetchSavedPlans();
+
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('일정이 삭제되었습니다.')),
+        );
+      }
+    }
   }
 
   @override
@@ -38,33 +72,59 @@ class _PlanListPageState extends ConsumerState<PlanListPage> {
       appBar: AppBar(
         title: const Text('나의 여행', style: AppTextStyles.appBarTitle),
         centerTitle: false,
+        actions: [
+          if (savedPlans.isNotEmpty)
+            TextButton(
+              onPressed: () {
+                setState(() {
+                  _isEditMode = !_isEditMode;
+                });
+              },
+              child: Text(
+                _isEditMode ? '완료' : '편집',
+                style: const TextStyle(color: Colors.blue),
+              ),
+            ),
+        ],
       ),
       body: SafeArea(
-        child:
-            savedPlans.isEmpty
-                ? Center(child: Text('여행 일정이 없습니다.'))
-                : ListView.builder(
-                  itemCount: savedPlans.length,
-                  itemBuilder: (context, index) {
-                    return MyPageListItem(
-                      itemTitle:
-                          '${formatMonthDay(savedPlans[index].startDate)}~${formatMonthDay(savedPlans[index].startDate)} ${formatRegion(savedPlans[index].region)} 여행',
-                      index: index,
-                      onTap: () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder:
-                                (context) => SchedulePage(
-                                  userId: user!.uid,
-                                  planId: savedPlans[index].planId,
+        child: savedPlans.isEmpty
+            ? const Center(child: Text('여행 일정이 없습니다.'))
+            : ListView.builder(
+                itemCount: savedPlans.length,
+                itemBuilder: (context, index) {
+                  final plan = savedPlans[index];
+                  return Row(
+                    children: [
+                      if (_isEditMode)
+                        IconButton(
+                          icon:  Icon(Icons.delete, color: AppColors.primary[300]!),
+                          onPressed: () => _showDeleteDialog(plan.planId),
+                        ),
+                      Expanded(
+                        child: MyPageListItem(
+                          itemTitle:
+                              '${formatMonthDay(plan.startDate)}~${formatMonthDay(plan.endDate)} ${formatRegion(plan.region)} 여행',
+                          index: index,
+                          onTap: () {
+                            if (!_isEditMode) {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (context) => SchedulePage(
+                                    userId: user!.uid,
+                                    planId: plan.planId,
+                                  ),
                                 ),
-                          ),
-                        );
-                      },
-                    );
-                  },
-                ),
+                              );
+                            }
+                          },
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
       ),
       bottomNavigationBar: const BottomBar(),
     );

--- a/lib/views/plan/plan/place_search/place_search_page.dart
+++ b/lib/views/plan/plan/place_search/place_search_page.dart
@@ -55,6 +55,10 @@ class _PlaceSearchPageState extends ConsumerState<PlaceSearchPage> {
   @override
   void initState() {
     super.initState();
+     WidgetsBinding.instance.addPostFrameCallback((_) {
+    ref.read(selectedIndexProvider.notifier).clear();
+  });
+
     _loadRecommendedPlacesByRegion();
   }
 

--- a/lib/views/plan/plan/schedule/schedule_page.dart
+++ b/lib/views/plan/plan/schedule/schedule_page.dart
@@ -73,10 +73,6 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
         daySchedules.putIfAbsent(dayIndex, () => []);
         daySchedules[dayIndex]!.addAll(selectedPlaces);
       });
-
-      await ref
-          .read(scheduleViewModelProvider.notifier)
-          .saveDaySchedules(planId: widget.planId, daySchedules: daySchedules);
     }
   }
 


### PR DESCRIPTION
### 🚀: 개요
-일정 저장 방식 개선
- 일정 삭제 기능 추가
- 검색 재진입 시 선택 상태 초기화 

### 🚀: 작업 내용
- 장소 추가 시 즉시 저장되던 기존 로직 제거
- PlanListPage 상단에 편집버튼 추가
- 편집 모드에서 각 일정 옆에 삭제 버튼 표시
- 삭제 시 AlertDialog 확인 -> 스낵바로 결과 안내
- Firestore 및 상태 동기화 로직 추가
- WidgetsBinding.instance.addPostFrameCallback 내에서 selectedIndexProvider.clear() 호출

### 📸: 실행 화면
![Screenshot_1750420821](https://github.com/user-attachments/assets/ef6342ac-5240-4770-be17-d1fe68ed9c8e)

### 🚀: 조정 파일
- place_search_page.dart
- plan_list_page.dart
- schedule_view_model.dart
- schedule_repository.dart
- schedule_page.dart

### 개발 결과
- 일정 일괄 저장으로 저장 방식 개선
- 일정 삭제 기능 추가 완료
- PlaceSearchPage 진입 시 이전 선택 상태가 남아있는 문제 해결

### issue
Closes #179 
