### PR TITLE
[AI]일정 내 장소들을 중심 좌표 기준 거리순으로 재정렬하는 기능 구현

### DIFF
--- a/lib/utills/distance_sort.dart
+++ b/lib/utills/distance_sort.dart
@@ -18,19 +18,19 @@ double calculateDistance(double lat1, double lng1, double lat2, double lng2) {
 double _toRadians(double degree) => degree * pi / 180;
 
 /// 중심 좌표(평균값) 계산
-Map<String, double> getCenterCoordinate(List<Map<String, dynamic>> places) {
+Map<String, double> getCenterCoordinate(List<Map<String, String>> places) {
   final avgLat =
-      places.map((p) => double.parse(p['lat'])).reduce((a, b) => a + b) /
+      places.map((p) => double.parse(p['lat']!)).reduce((a, b) => a + b) /
       places.length;
   final avgLng =
-      places.map((p) => double.parse(p['lng'])).reduce((a, b) => a + b) /
+      places.map((p) => double.parse(p['lng']!)).reduce((a, b) => a + b) /
       places.length;
   return {'lat': avgLat, 'lng': avgLng};
 }
 
 /// 가까운 거리순 정렬
-List<Map<String, dynamic>> sortPlacesByDistance(
-  List<Map<String, dynamic>> places,
+List<Map<String, String>> sortPlacesByDistance(
+  List<Map<String, String>> places,
 ) {
   final center = getCenterCoordinate(places);
 
@@ -38,14 +38,14 @@ List<Map<String, dynamic>> sortPlacesByDistance(
     final distA = calculateDistance(
       center['lat']!,
       center['lng']!,
-      double.parse(a['lat']),
-      double.parse(a['lng']),
+      double.parse(a['lat']!),
+      double.parse(a['lng']!),
     );
     final distB = calculateDistance(
       center['lat']!,
       center['lng']!,
-      double.parse(b['lat']),
-      double.parse(b['lng']),
+      double.parse(b['lat']!),
+      double.parse(b['lng']!),
     );
     return distA.compareTo(distB);
   });

--- a/lib/utills/distance_sort.dart
+++ b/lib/utills/distance_sort.dart
@@ -1,0 +1,54 @@
+import 'dart:math';
+
+/// 위경도 기반 거리 계산
+double calculateDistance(double lat1, double lng1, double lat2, double lng2) {
+  const earthRadius = 6371.0; // 단위: km
+  final dLat = _toRadians(lat2 - lat1);
+  final dLng = _toRadians(lng2 - lng1);
+  final a =
+      sin(dLat / 2) * sin(dLat / 2) +
+      cos(_toRadians(lat1)) *
+          cos(_toRadians(lat2)) *
+          sin(dLng / 2) *
+          sin(dLng / 2);
+  final c = 2 * atan2(sqrt(a), sqrt(1 - a));
+  return earthRadius * c;
+}
+
+double _toRadians(double degree) => degree * pi / 180;
+
+/// 중심 좌표(평균값) 계산
+Map<String, double> getCenterCoordinate(List<Map<String, dynamic>> places) {
+  final avgLat =
+      places.map((p) => double.parse(p['lat'])).reduce((a, b) => a + b) /
+      places.length;
+  final avgLng =
+      places.map((p) => double.parse(p['lng'])).reduce((a, b) => a + b) /
+      places.length;
+  return {'lat': avgLat, 'lng': avgLng};
+}
+
+/// 가까운 거리순 정렬
+List<Map<String, dynamic>> sortPlacesByDistance(
+  List<Map<String, dynamic>> places,
+) {
+  final center = getCenterCoordinate(places);
+
+  places.sort((a, b) {
+    final distA = calculateDistance(
+      center['lat']!,
+      center['lng']!,
+      double.parse(a['lat']),
+      double.parse(a['lng']),
+    );
+    final distB = calculateDistance(
+      center['lat']!,
+      center['lng']!,
+      double.parse(b['lat']),
+      double.parse(b['lng']),
+    );
+    return distA.compareTo(distB);
+  });
+
+  return places;
+}

--- a/lib/views/plan/plan/schedule/schedule_page.dart
+++ b/lib/views/plan/plan/schedule/schedule_page.dart
@@ -4,10 +4,12 @@ import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/models/plan/plans.dart';
 import 'package:travel_muse_app/providers/plan/schedule/schedule_provider.dart';
 import 'package:travel_muse_app/utills/date_utils.dart';
+import 'package:travel_muse_app/utills/distance_sort.dart';
 import 'package:travel_muse_app/views/home/home_page.dart';
 import 'package:travel_muse_app/views/plan/plan/place_search/place_search_page.dart';
 import 'package:travel_muse_app/views/plan/plan/schedule/widgets/ai_button.dart';
 import 'package:travel_muse_app/views/plan/plan/schedule/widgets/day_schedule_list.dart';
+import 'package:travel_muse_app/views/plan/plan/schedule/widgets/distance_sort_button.dart';
 import 'package:travel_muse_app/views/plan/plan/schedule/widgets/schedule_bottom_button.dart';
 import 'package:travel_muse_app/views/plan/plan/schedule/widgets/schedule_header.dart';
 import 'package:travel_muse_app/views/plan/plan/widgets/schedule_app_bar.dart';
@@ -159,26 +161,37 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
       ),
 
       floatingActionButton: Padding(
-        padding: const EdgeInsets.only(bottom: 60, top: 8),
-        child: Align(
-          alignment: Alignment.bottomRight,
-          child: AiButton(
-            planId: widget.planId,
-            days: calculateTripDays(
-              selectedPlan!.startDate,
-              selectedPlan!.endDate,
+        padding: const EdgeInsets.only(bottom: 60, right: 16, left: 16),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            DistanceSortButton(
+              daySchedules: daySchedules,
+              onResult: (sorted) {
+                setState(() {
+                  daySchedules = sorted;
+                });
+              },
             ),
-            region: selectedPlan!.region,
-            onResult: (parsed) {
-              setState(() {
-                daySchedules = parsed;
-              });
-            },
-          ),
+
+            // 오른쪽: AI 추천 버튼
+            AiButton(
+              planId: widget.planId,
+              days: calculateTripDays(
+                selectedPlan!.startDate,
+                selectedPlan!.endDate,
+              ),
+              region: selectedPlan!.region,
+              onResult: (parsed) {
+                setState(() {
+                  daySchedules = parsed;
+                });
+              },
+            ),
+          ],
         ),
       ),
-
-      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
 
       bottomNavigationBar: const BottomBar(),
     );

--- a/lib/views/plan/plan/schedule/widgets/distance_sort_button.dart
+++ b/lib/views/plan/plan/schedule/widgets/distance_sort_button.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/utills/distance_sort.dart';
+
+class DistanceSortButton extends StatelessWidget {
+  const DistanceSortButton({
+    super.key,
+    required this.daySchedules,
+    required this.onResult,
+  });
+
+  final Map<int, List<Map<String, String>>> daySchedules;
+  final void Function(Map<int, List<Map<String, String>>>) onResult;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        final sorted = <int, List<Map<String, String>>>{};
+
+        for (final entry in daySchedules.entries) {
+          final day = entry.key;
+          final places = entry.value;
+
+          final canSort = places.every(
+            (p) => p['lat'] != null && p['lng'] != null,
+          );
+
+          if (canSort) {
+            try {
+              final sortedPlaces = sortPlacesByDistance(places);
+              sorted[day] = sortedPlaces;
+            } catch (e) {
+              sorted[day] = places;
+            }
+          } else {
+            sorted[day] = places;
+          }
+        }
+
+        onResult(sorted);
+      },
+      child: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              AppColors.primary[50]!,
+              AppColors.primary[300]!,
+              AppColors.primary[400]!,
+            ],
+            stops: const [0.0, 0.3, 0.7],
+            begin: Alignment.centerLeft,
+            end: Alignment.centerRight,
+          ),
+          borderRadius: const BorderRadius.all(Radius.circular(28)),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 10),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: const [
+            Icon(Icons.sort, size: 20, color: AppColors.white),
+            SizedBox(width: 5),
+            Text(
+              '거리순 정렬',
+              style: TextStyle(
+                color: AppColors.white,
+                fontSize: 18,
+                fontWeight: FontWeight.w600,
+                fontFamily: 'Pretendard',
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### 🚀: 개요
- 일정 내 장소들을 중심 좌표 기준 거리순으로 재정렬하는 기능 구현

### 🚀: 작업 내용
기존 FloatingActionButton.extended 방식 제거

DistanceSortButton 위젯 생성 (AI 추천 버튼과 동일한 스타일 적용)

sortPlacesByDistance() 로직 연동

일정 저장 버튼 위 좌측 정렬 UI로 위치 조정

daySchedules 상태에 바로 반영되도록 onResult() 전달 방식 사용

일정 내 장소들을 중심 좌표 기준 거리순으로 재정렬하는 기능 구현

### 📸: 실행 화면
### 📸: 실행 화면
<img src="https://github.com/user-attachments/assets/924fdbad-d866-486d-8975-d1efa235d813" width="300"/>


### 🚀: 조정 파일
schedule_page.dart

distance_sort.dart

distance_sort_button.dart

### 개발 결과
거리순 정렬 기능 정상 작동 확인

AI 버튼과 동일한 UI/UX로 정렬 버튼 일관성 확보

일정 내 장소들을 중심 좌표 기준 거리순으로 재정렬하는 기능 구현

### issue
Closes #180 
