### PR TITLE
[Etc] 스플래시 페이지, 홈페이지, 성향 결과 페이지의 유저정보 확인 불가 오류 픽스

### DIFF
--- a/lib/repositories/user/app_user_repository.dart
+++ b/lib/repositories/user/app_user_repository.dart
@@ -17,7 +17,9 @@ class AppUserRepository {
 
     final user = FirebaseAuth.instance.currentUser;
     final provider = user?.providerData.first;
-    if (provider == null) return;
+    if (provider == null) {
+      return;
+    }
 
     if (!snapshot.exists) {
       await docRef.set({
@@ -32,6 +34,11 @@ class AppUserRepository {
         'gender': null,
       });
     }
+  }
+
+  Future<bool> doesUserDocumentExist(String uid) async {
+    final doc = await _firestore.collection('appUser').doc(uid).get();
+    return doc.exists;
   }
 
   /// 데이터베이스에서 uid로 해당 유저 정보 get

--- a/lib/repositories/user/app_user_repository.dart
+++ b/lib/repositories/user/app_user_repository.dart
@@ -163,6 +163,16 @@ class AppUserRepository {
       await doc.reference.delete();
     }
 
+    // preference_test 문서 중 userId == user.uid 인 문서 모두 삭제
+    final preferenceSnapshot =
+        await _firestore
+            .collection('preference_test')
+            .where('userId', isEqualTo: user.uid)
+            .get();
+    for (final doc in preferenceSnapshot.docs) {
+      await doc.reference.delete();
+    }
+
     await userDocRef.delete();
   }
 }

--- a/lib/services/user/auth_service.dart
+++ b/lib/services/user/auth_service.dart
@@ -22,6 +22,8 @@ class AuthService {
     try {
       final googleUser = await _googleSignIn.signIn();
       if (googleUser == null) {
+        await _googleSignIn.signOut();
+        await _firebaseAuth.signOut();
         return Result.failure('유저 취소');
       }
 
@@ -74,6 +76,7 @@ class AuthService {
       return Result.failure('네트워크 오류');
     } on SignInWithAppleAuthorizationException catch (e) {
       if (e.code == AuthorizationErrorCode.canceled) {
+        await _firebaseAuth.signOut();
         return Result.failure('유저 취소');
       }
       return Result.failure('Apple 로그인 오류: ${e.message}');
@@ -83,6 +86,7 @@ class AuthService {
   }
 
   Future<void> signOut() async {
+    await _googleSignIn.signOut();
     await _firebaseAuth.signOut();
   }
 }

--- a/lib/viewmodels/user/app_user_view_model.dart
+++ b/lib/viewmodels/user/app_user_view_model.dart
@@ -2,6 +2,7 @@ import 'dart:developer';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travel_muse_app/models/user/app_user_model.dart';
 import 'package:travel_muse_app/models/user/app_user_state_model.dart';
 import 'package:travel_muse_app/repositories/user/app_user_repository.dart';
 
@@ -15,12 +16,12 @@ class AppUserViewModel extends AutoDisposeAsyncNotifier<AppUserState> {
     return AppUserState();
   }
 
-  Future<void> fetchAppUser() async {
+  Future<AppUser?> fetchAppUser() async {
     try {
-      if (currentUser == null) return;
+      if (currentUser == null) return null;
       final appUser = await _repository.fetchLatestAppUser(currentUser!.uid);
 
-      if (appUser == null) return;
+      if (appUser == null) return null;
       state = AsyncData(
         state.value!.copyWith(
           uid: appUser.uid,
@@ -34,8 +35,19 @@ class AppUserViewModel extends AutoDisposeAsyncNotifier<AppUserState> {
           testId: appUser.testId,
         ),
       );
+      return appUser;
     } catch (e) {
       log('기존 유저정보 로드 실패: $e');
+      return null;
+    }
+  }
+
+  Future<bool> doesUserDocumentExist(String uid) async {
+    try {
+      return await _repository.doesUserDocumentExist(uid);
+    } catch (e) {
+      log('해당 uid 문서 존재 여부 확인 실패 : $e');
+      return false;
     }
   }
 }

--- a/lib/viewmodels/user/auth_view_model.dart
+++ b/lib/viewmodels/user/auth_view_model.dart
@@ -75,7 +75,7 @@ class AuthViewModel extends Notifier<AuthState> {
   /// 로그아웃
   Future<void> logout() async {
     await _authService.signOut();
-    state = AuthState();
+    state = AuthState(user: null, appUser: null, isUserNew: null);
   }
 
   /// 탈퇴 처리
@@ -84,6 +84,7 @@ class AuthViewModel extends Notifier<AuthState> {
 
     try {
       await _repository.deleteAccount();
+      await _authService.signOut();
     } catch (e) {
       log('탈퇴 처리 실패 : $e');
     }

--- a/lib/views/home/home_page.dart
+++ b/lib/views/home/home_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
-import 'package:travel_muse_app/providers/user/profile_view_model_provider.dart';
+import 'package:travel_muse_app/providers/user/app_user_view_model_provider.dart';
 import 'package:travel_muse_app/views/home/widgets/info_banner.dart';
 import 'package:travel_muse_app/views/home/widgets/recommended_places_list.dart';
 import 'package:travel_muse_app/views/home/widgets/recommended_restaurants_list.dart';
@@ -14,60 +14,62 @@ class HomePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final profileState = ref.watch(profileViewModelProvider);
-    final nickname = profileState.currentNickname;
-    if (nickname == null) {
-      return const Center(child: CircularProgressIndicator());
-    }
+    final appUserAsync = ref.watch(appUserViewModelProvider);
+
     return Scaffold(
       backgroundColor: AppColors.white,
       body: SafeArea(
-        child: SingleChildScrollView(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Padding(
-                padding: const EdgeInsets.all(16),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
+        child: appUserAsync.when(
+          data:
+              (data) => SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Image.asset(
-                      'assets/images/Logo.png',
-                      width: 20,
-                      height: 20,
-                      fit: BoxFit.contain,
-                    ),
-                    const SizedBox(width: 8),
-                    Text(
-                      'Travelmuse',
-                      style: TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.bold,
-                        color: AppColors.grey[800],
-                        fontFamily: 'Ssangmun',
+                    Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.center,
+                        children: [
+                          Image.asset(
+                            'assets/images/Logo.png',
+                            width: 20,
+                            height: 20,
+                            fit: BoxFit.contain,
+                          ),
+                          const SizedBox(width: 8),
+                          Text(
+                            'Travelmuse',
+                            style: TextStyle(
+                              fontSize: 18,
+                              fontWeight: FontWeight.bold,
+                              color: AppColors.grey[800],
+                              fontFamily: 'Ssangmun',
+                            ),
+                          ),
+                        ],
                       ),
                     ),
+                    const InfoBanner(),
+                    const SizedBox(height: 8),
+                    Center(child: TravelRegisterButton()),
+                    const SizedBox(height: 24),
+
+                    SectionTitle(title: '${data.nickname}님의 위치 기반 추천 명소예요'),
+
+                    const SizedBox(height: 8),
+                    const RecommendedPlacesList(),
+                    const SizedBox(height: 10),
+
+                    SectionTitle(title: '최근 유행하는 맛집이에요'),
+
+                    const SizedBox(height: 8),
+                    const RecommendedRestaurantsList(),
+                    const SizedBox(height: 24),
                   ],
                 ),
               ),
-              const InfoBanner(),
-              const SizedBox(height: 8),
-              Center(child: TravelRegisterButton()),
-              const SizedBox(height: 24),
-
-              SectionTitle(title: '$nickname님의 위치 기반 추천 명소예요'),
-
-              const SizedBox(height: 8),
-              const RecommendedPlacesList(),
-              const SizedBox(height: 10),
-
-              SectionTitle(title: '최근 유행하는 맛집이에요'),
-
-              const SizedBox(height: 8),
-              const RecommendedRestaurantsList(),
-              const SizedBox(height: 24),
-            ],
-          ),
+          error: (e, st) => Text('홈 화면 불러오기 실패. 앱을 재시작해 주세요.'),
+          loading: () => CircularProgressIndicator(),
         ),
       ),
       bottomNavigationBar: const BottomBar(),

--- a/lib/views/home/widgets/info_banner.dart
+++ b/lib/views/home/widgets/info_banner.dart
@@ -4,8 +4,8 @@ import 'package:intl/intl.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/widgets/svg_icon.dart';
 import 'package:travel_muse_app/providers/plan/calendar_location_provider.dart';
+import 'package:travel_muse_app/providers/user/app_user_view_model_provider.dart';
 import 'package:travel_muse_app/providers/user/auth_view_model_provider.dart';
-import 'package:travel_muse_app/providers/user/profile_view_model_provider.dart';
 import 'package:travel_muse_app/views/plan/plan/schedule/schedule_page.dart';
 
 class InfoBanner extends ConsumerWidget {
@@ -13,11 +13,7 @@ class InfoBanner extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final profileState = ref.watch(profileViewModelProvider);
-    final nickname = profileState.currentNickname;
-    if (nickname == null) {
-      return const Center(child: CircularProgressIndicator());
-    }
+    final appUserAsync = ref.watch(appUserViewModelProvider);
     final planState = ref.watch(calendarLocationViewModelProvider);
     final userId = ref.watch(authViewModelProvider).user?.uid;
     final planId = ref.watch(
@@ -85,76 +81,85 @@ class InfoBanner extends ConsumerWidget {
       );
     }
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.end,
-        children: [
-          Align(
-            alignment: Alignment.centerLeft,
-            child: Text(
-              '$nickname님,\n${calculateRemainingDays(start) == '여행 중이에요!' || calculateRemainingDays(start) == '오늘부터 여행이에요!' ? '${getMainRegion(region)} ${calculateRemainingDays(start)}' : '${getMainRegion(region)} 여행까지 ${calculateRemainingDays(start)}'}',
-              style: const TextStyle(
-                fontSize: 24,
-                fontWeight: FontWeight.w700,
-                color: AppColors.black,
-                height: 1.5,
-              ),
-            ),
-          ),
-          const SizedBox(height: 4),
-          Align(
-            alignment: Alignment.centerLeft,
-            child: Text(
-              '${end.difference(start).inDays}박 ${end.difference(start).inDays + 1}일 | ${formatDate(start)} - ${formatDate(end)}',
-              style: TextStyle(
-                fontSize: 14,
-                color: AppColors.grey[400],
-                fontWeight: FontWeight.w400,
-              ),
-            ),
-          ),
-          TextButton(
-            onPressed: () {
-              if (userId == null) {
-                ScaffoldMessenger.of(
-                  context,
-                ).showSnackBar(const SnackBar(content: Text('로그인 정보가 없습니다.')));
-                return;
-              }
-
-              if (planId == null) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('유효한 계획 ID가 없습니다.')),
-                );
-                return;
-              }
-
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (_) => SchedulePage(userId: userId, planId: planId),
-                ),
-              );
-            },
-            style: TextButton.styleFrom(padding: EdgeInsets.zero),
-            child: Align(
-              alignment: Alignment.centerRight,
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    '자세히 보기',
-                    style: TextStyle(fontSize: 14, color: AppColors.grey[300]),
+    return appUserAsync.when(
+      data:
+          (data) => Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '${data.nickname}님,\n${calculateRemainingDays(start) == '여행 중이에요!' || calculateRemainingDays(start) == '오늘부터 여행이에요!' ? '${getMainRegion(region)} ${calculateRemainingDays(start)}' : '${getMainRegion(region)} 여행까지 ${calculateRemainingDays(start)}'}',
+                    style: const TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.w700,
+                      color: AppColors.black,
+                      height: 1.5,
+                    ),
                   ),
-                  const SizedBox(width: 4),
-                  SvgIcon.rightArrow(width: 24, height: 24),
-                ],
-              ),
+                ),
+                const SizedBox(height: 4),
+                Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    '${end.difference(start).inDays}박 ${end.difference(start).inDays + 1}일 | ${formatDate(start)} - ${formatDate(end)}',
+                    style: TextStyle(
+                      fontSize: 14,
+                      color: AppColors.grey[400],
+                      fontWeight: FontWeight.w400,
+                    ),
+                  ),
+                ),
+                TextButton(
+                  onPressed: () {
+                    if (userId == null) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('로그인 정보가 없습니다.')),
+                      );
+                      return;
+                    }
+
+                    if (planId == null) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('유효한 계획 ID가 없습니다.')),
+                      );
+                      return;
+                    }
+
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder:
+                            (_) => SchedulePage(userId: userId, planId: planId),
+                      ),
+                    );
+                  },
+                  style: TextButton.styleFrom(padding: EdgeInsets.zero),
+                  child: Align(
+                    alignment: Alignment.centerRight,
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          '자세히 보기',
+                          style: TextStyle(
+                            fontSize: 14,
+                            color: AppColors.grey[300],
+                          ),
+                        ),
+                        const SizedBox(width: 4),
+                        SvgIcon.rightArrow(width: 24, height: 24),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
             ),
           ),
-        ],
-      ),
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, st) => const Text('사용자 정보를 불러올 수 없습니다.'),
     );
   }
 }

--- a/lib/views/preference/widgets/result_view.dart
+++ b/lib/views/preference/widgets/result_view.dart
@@ -4,7 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/providers/preference/preference_test_provider.dart';
-import 'package:travel_muse_app/providers/user/profile_view_model_provider.dart';
+import 'package:travel_muse_app/providers/user/app_user_view_model_provider.dart';
 import 'package:travel_muse_app/views/preference/widgets/result_action_buttons.dart';
 import 'package:travel_muse_app/views/preference/widgets/result_view_detail.dart';
 
@@ -50,14 +50,11 @@ class _ResultViewState extends ConsumerState<ResultView> {
   Widget build(BuildContext context) {
     final state = ref.watch(preferenceTestStateNotifierProvider);
     final result = state.value?.result;
-    final profileState = ref.watch(profileViewModelProvider);
-    final nickname = profileState.currentNickname;
-    if (nickname == null) {
-      return const Center(child: CircularProgressIndicator());
-    }
     final typeCode = result?['type'];
     final description = result?['details'];
     final imagePath = resultImageMap[typeCode] ?? '';
+
+    final appUserAsync = ref.watch(appUserViewModelProvider);
 
     if (state.isLoading || typeCode == null || description == null) {
       return const Center(child: CircularProgressIndicator());
@@ -134,101 +131,106 @@ class _ResultViewState extends ConsumerState<ResultView> {
               )
               : null,
       backgroundColor: AppColors.white,
-      body: Stack(
-        children: [
-          ListView(
-            children: [
-              Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 24,
-                ),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+      body: appUserAsync.when(
+        data:
+            (data) => Stack(
+              children: [
+                ListView(
                   children: [
-                    Text(
-                      '$nickname님의 여행 성향은 \n$typeCode예요!',
-                      style: AppTextStyles.onboardingTitle.copyWith(
-                        fontWeight: FontWeight.w700,
+                    Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 24,
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '${data.nickname}님의 여행 성향은 \n$typeCode예요!',
+                            style: AppTextStyles.onboardingTitle.copyWith(
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            '${data.nickname}님의 여행 성향은 마이페이지에서 \n언제든지 확인할 수 있어요',
+                            style: AppTextStyles.onboardingSubTitle,
+                          ),
+                        ],
                       ),
                     ),
-                    const SizedBox(height: 8),
-                    Text(
-                      '$nickname님의 여행 성향은 마이페이지에서 \n언제든지 확인할 수 있어요',
-                      style: AppTextStyles.onboardingSubTitle,
+
+                    Padding(
+                      padding: const EdgeInsets.all(16.0),
+                      child: Align(
+                        alignment: Alignment.center,
+                        child: ClipOval(
+                          child: Container(
+                            width: 198,
+                            height: 198,
+                            color: AppColors.white,
+                            child:
+                                imagePath.isNotEmpty
+                                    ? Image.asset(imagePath, fit: BoxFit.cover)
+                                    : const Icon(
+                                      CupertinoIcons.exclamationmark_triangle,
+                                      size: 48,
+                                      color: Colors.red,
+                                    ),
+                          ),
+                        ),
+                      ),
+                    ),
+
+                    const SizedBox(height: 24),
+                    Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: Text(
+                        description,
+                        textAlign: TextAlign.center,
+                        style: AppTextStyles.preferenceDescriptionText,
+                      ),
+                    ),
+                    SizedBox(height: 10),
+                    CupertinoButton(
+                      padding: EdgeInsets.zero,
+                      onPressed: () {
+                        Navigator.push(
+                          context,
+                          CupertinoPageRoute(
+                            builder: (_) => const ResultViewDetail(),
+                          ),
+                        );
+                      },
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text('선택지 보기', style: AppTextStyles.helperText),
+                          const SizedBox(width: 4),
+                          Icon(
+                            CupertinoIcons.chevron_right,
+                            size: 16,
+                            color: AppColors.grey[400],
+                          ),
+                        ],
+                      ),
                     ),
                   ],
                 ),
-              ),
+                widget.showButtons
+                    ? Column(
+                      children: [
+                        Spacer(),
 
-              Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Align(
-                  alignment: Alignment.center,
-                  child: ClipOval(
-                    child: Container(
-                      width: 198,
-                      height: 198,
-                      color: AppColors.white,
-                      child:
-                          imagePath.isNotEmpty
-                              ? Image.asset(imagePath, fit: BoxFit.cover)
-                              : const Icon(
-                                CupertinoIcons.exclamationmark_triangle,
-                                size: 48,
-                                color: Colors.red,
-                              ),
-                    ),
-                  ),
-                ),
-              ),
-
-              const SizedBox(height: 24),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 16),
-                child: Text(
-                  description,
-                  textAlign: TextAlign.center,
-                  style: AppTextStyles.preferenceDescriptionText,
-                ),
-              ),
-              SizedBox(height: 10),
-              CupertinoButton(
-                padding: EdgeInsets.zero,
-                onPressed: () {
-                  Navigator.push(
-                    context,
-                    CupertinoPageRoute(
-                      builder: (_) => const ResultViewDetail(),
-                    ),
-                  );
-                },
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Text('선택지 보기', style: AppTextStyles.helperText),
-                    const SizedBox(width: 4),
-                    Icon(
-                      CupertinoIcons.chevron_right,
-                      size: 16,
-                      color: AppColors.grey[400],
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-          widget.showButtons
-              ? Column(
-                children: [
-                  Spacer(),
-
-                  ResultActionButtons(onRestart: widget.onRestart),
-                  const SizedBox(height: 34),
-                ],
-              )
-              : SizedBox.shrink(),
-        ],
+                        ResultActionButtons(onRestart: widget.onRestart),
+                        const SizedBox(height: 34),
+                      ],
+                    )
+                    : SizedBox.shrink(),
+              ],
+            ),
+        error: (e, st) => Text('성향 검사 결과 불러오기 실패. 앱을 재시작해 주세요.'),
+        loading: () => CircularProgressIndicator(),
       ),
     );
   }

--- a/lib/views/user/login/widgets/sns_login_bar.dart
+++ b/lib/views/user/login/widgets/sns_login_bar.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
+import 'dart:developer';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/providers/user/app_user_view_model_provider.dart';
 import 'package:travel_muse_app/providers/user/auth_view_model_provider.dart';
 import 'package:travel_muse_app/views/home/home_page.dart';
 import 'package:travel_muse_app/views/user/onboarding/onboarding_page.dart';
@@ -30,16 +32,23 @@ class SnsLoginBar extends ConsumerWidget {
         await loginFunction();
         final state = ref.watch(authViewModelProvider);
         if (state.user != null) {
-          final isNew = ref.read(authViewModelProvider).isUserNew;
+          log('sns로그인 성공');
+          final hasAppUserDoc = await ref
+              .read(appUserViewModelProvider.notifier)
+              .doesUserDocumentExist(state.user!.uid);
+          log('appUser 문서 생성되었는가? : $hasAppUserDoc');
+          if (hasAppUserDoc) {
+            final isNew = ref.read(authViewModelProvider).isUserNew;
+            final nextPage =
+                isNew != null ? const OnboardingPage() : const HomePage();
+            log('nextPage == $nextPage');
 
-          final nextPage =
-              isNew != null ? const OnboardingPage() : const HomePage();
-
-          unawaited(
-            navigator.pushReplacement(
-              MaterialPageRoute(builder: (_) => nextPage),
-            ),
-          );
+            unawaited(
+              navigator.pushReplacement(
+                MaterialPageRoute(builder: (_) => nextPage),
+              ),
+            );
+          }
         }
       },
       child: Container(

--- a/lib/views/user/onboarding/onboarding_page.dart
+++ b/lib/views/user/onboarding/onboarding_page.dart
@@ -53,13 +53,15 @@ class OnboardingPage extends ConsumerWidget {
                     isActivated: canUpdate,
                     onPressed: () {
                       if (canUpdate) {
-                        showModalBottomSheet(
-                          context: context,
-                          isScrollControlled: true,
-                          builder: (context) {
-                            return const TermsAgreementBottomSheet();
-                          },
-                        );
+                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                          if (!context.mounted) return;
+                          showModalBottomSheet(
+                            context: context,
+                            isScrollControlled: true,
+                            builder:
+                                (context) => const TermsAgreementBottomSheet(),
+                          );
+                        });
                       }
                     },
                   ),

--- a/lib/views/user/onboarding/terms_agreement_bottom_sheet.dart
+++ b/lib/views/user/onboarding/terms_agreement_bottom_sheet.dart
@@ -58,8 +58,9 @@ class TermsAgreementBottomSheet extends ConsumerWidget {
                   await profileViewmodel.updateProfile();
                   await agreementViewmodel.uploadUserAgreements();
                   unawaited(
-                    navigator.push(
+                    navigator.pushAndRemoveUntil(
                       MaterialPageRoute(builder: (_) => PreferenceIntroPage2()),
+                      (route) => false,
                     ),
                   );
                 }

--- a/lib/views/user/splash/splash_page.dart
+++ b/lib/views/user/splash/splash_page.dart
@@ -3,6 +3,7 @@ import 'dart:developer';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/providers/user/app_user_view_model_provider.dart';
 import 'package:travel_muse_app/providers/user/auth_view_model_provider.dart';
 import 'package:travel_muse_app/views/home/home_page.dart';
 import 'package:travel_muse_app/views/user/login/login_page.dart';
@@ -30,17 +31,24 @@ class _SplashScreenState extends ConsumerState<SplashPage> {
     Widget nextPage = const LoginPage();
 
     final authState = ref.read(authViewModelProvider);
-    log('유저 정보가 있는가? : ${authState.user != null}');
+    log('구글/애플 로그인 정보가 있는가? : ${authState.user != null}');
     if (authState.user != null) {
-      final viewmodel = ref.read(authViewModelProvider.notifier);
-      await viewmodel.isUserNew();
+      final hasAppUserDoc = await ref
+          .read(appUserViewModelProvider.notifier)
+          .doesUserDocumentExist(authState.user!.uid);
 
-      final updatedState = ref.read(authViewModelProvider);
-      log('유저 문서가 있는가? : ${updatedState.isUserNew != null}');
-      if (updatedState.isUserNew != null) {
-        nextPage = const OnboardingPage();
-      } else {
-        nextPage = const HomePage();
+      log('appUser 문서가 있는가? $hasAppUserDoc');
+      if (hasAppUserDoc) {
+        final appUserState =
+            await ref.read(appUserViewModelProvider.notifier).fetchAppUser();
+        final nickname = appUserState?.nickname;
+        log('온보딩이 완료되었는가? ${nickname != null}');
+
+        if (nickname == null) {
+          nextPage = const OnboardingPage();
+        } else {
+          nextPage = const HomePage();
+        }
       }
     }
 


### PR DESCRIPTION
###  🚀: 개요
- 스플래시 페이지, 홈페이지, 성향 결과 페이지의 유저정보 확인 불가 오류 픽스

###  🚀: 작업 내용
- 스플래시 페이지, 홈페이지, 성향 결과 페이지에서 사용하는 뷰모델 스테이트 변경
- 스플래시 페이지 페이지 이동 분기 조건 픽스
- 로그인 취소, 탈퇴, 로그인 후 온보딩 미진행 등의 다양한 상황 대응

###  📸: 실행 화면

###  🚀: 조정 파일
- lib/repositories/user/app_user_repository.dart
- lib/services/user/auth_service.dart
- lib/viewmodels/user/app_user_view_model.dart
- lib/viewmodels/user/auth_view_model.dart
- lib/views/home/home_page.dart
- lib/views/home/widgets/info_banner.dart
- lib/views/preference/widgets/result_view.dart
- lib/views/user/login/widgets/sns_login_bar.dart
- lib/views/user/onboarding/onboarding_page.dart
- lib/views/user/onboarding/terms_agreement_bottom_sheet.dart
- lib/views/user/splash/splash_page.dart

###  개발 결과
- 스플래시 페이지, 홈페이지, 성향 결과 페이지에서 공통적으로 현재 유저 nickname== null 을 조건으로 하는 분기들의 오류 픽스
- 스플래시 페이지 이후 페이지 이동 분기 조건 세분화
- 로그인 취소 시, 탈퇴 시, 로그인 후 온보딩 하지 않은 경우 대응 페이지 네이게이터 구현

### issue
Closes #195
