### PR TITLE
[Post] 포스팅 위치 추가하기 기능 추가 

### DIFF
--- a/lib/models/home/home_place.dart
+++ b/lib/models/home/home_place.dart
@@ -6,6 +6,7 @@ class HomePlace {
     required this.id,
     required this.title,
     required this.subtitle,
+    required this.address,
     required this.thumbnail,
     required this.latLng,
     required this.category,
@@ -18,6 +19,7 @@ class HomePlace {
   final String id;
   final String title;
   final String subtitle;
+  final String address;
   final String thumbnail;
   final LatLng latLng;
   final String category;
@@ -31,6 +33,7 @@ class HomePlace {
       id: p.id,
       title: p.name,
       subtitle: p.address,
+      address: p.address,
       thumbnail: thumb,
       latLng: LatLng(p.latitude, p.longitude),
       category: p.category,
@@ -45,7 +48,8 @@ class HomePlace {
       id: map['id'] ?? '',
       title: map['title'] ?? '',
       subtitle: map['subtitle'] ?? '',
-      thumbnail: map['image'] ?? '', 
+      address: map['address'] ?? '',
+      thumbnail: map['image'] ?? '',
       latLng: LatLng(
         double.tryParse(map['lat']?.toString() ?? '0') ?? 0,
         double.tryParse(map['lng']?.toString() ?? '0') ?? 0,
@@ -64,9 +68,12 @@ extension PlaceMapping on Place {
     id: id,
     title: name,
     subtitle: address,
+    address: address,
     thumbnail: thumb,
     latLng: LatLng(latitude, longitude),
     category: category,
+    phone: phone,
+    placeUrl: placeUrl,
     distance: distance,
   );
 }

--- a/lib/models/post/post_model.dart
+++ b/lib/models/post/post_model.dart
@@ -15,6 +15,7 @@ class Post {
     required this.isReposted,
     required this.reportCount,
     required this.tags,
+    required this.place,
   });
   final String postId;
   final String userId;
@@ -29,6 +30,7 @@ class Post {
   final bool isDeleted;
   final bool isReposted;
   final int reportCount;
+  final Map<String, dynamic>? place;
 
   factory Post.fromMap(Map<String, dynamic> map) {
     return Post(
@@ -48,6 +50,7 @@ class Post {
       isReposted: map['isReposted'] ?? false,
       reportCount: map['reportCount'] ?? 0,
       title: map['title'] ?? '',
+      place: map['place'],
     );
   }
   Map<String, dynamic> toMap({required bool isNew}) {
@@ -65,6 +68,7 @@ class Post {
       'isReposted': isReposted,
       'reportCount': reportCount,
       'tags': tags,
+      'place': place,
     };
   }
 }

--- a/lib/providers/plan/schedule/search_provider.dart
+++ b/lib/providers/plan/schedule/search_provider.dart
@@ -3,12 +3,11 @@ import 'package:travel_muse_app/providers/plan/schedule/nearby_place_service_pro
 import 'package:travel_muse_app/providers/plan/schedule/place_search_service_provider.dart';
 import 'package:travel_muse_app/viewmodels/plan/search_view_model.dart';
 
-
 /// 장소 검색 기능을 담당하는 ViewModel Provider
 /// 검색 키워드 기반 장소 검색과 현재 위치 기반 근처 장소 검색을 모두 처리합니다.
 final searchViewModelProvider =
     StateNotifierProvider<SearchViewModel, List<Map<String, String>>>((ref) {
       final placeSvc = ref.watch(placeSearchServiceProvider);
       final nearbySvc = ref.watch(nearbyPlaceServiceProvider);
-      return SearchViewModel(placeSvc, nearbySvc);
+      return SearchViewModel(ref, placeSvc, nearbySvc);
     });

--- a/lib/repositories/post/post_repository.dart
+++ b/lib/repositories/post/post_repository.dart
@@ -39,12 +39,14 @@ class PostRepository {
     String content,
     List<String> imageUrls,
     List<String> tags,
+    Map<String, dynamic>? place,
   ) async {
     await _postRef.doc(postId).update({
       'title': title,
       'content': content,
       'images': imageUrls,
       'tags': tags,
+      'place': place,
       'updatedAt': FieldValue.serverTimestamp(),
     });
   }

--- a/lib/utills/map_utils.dart
+++ b/lib/utills/map_utils.dart
@@ -4,39 +4,52 @@ import 'package:travel_muse_app/utills/latlng_helper.dart';
 /// 여행 장소 리스트를 기반으로 Google Maps에 표시할 마커들을 생성합니다.
 Set<Marker> createMarkers({
   required List<Map<String, dynamic>> places,
-    required BitmapDescriptor icon,
+  required BitmapDescriptor icon,
   required Function(Map<String, dynamic>) onTap,
   required Function(int) onPageChanged,
-  required Function(int) animateToPage,
+  required Function(int)? animateToPage,
 }) {
-  return places.asMap().entries.map((entry) {
-    final index = entry.key;
-    final place = entry.value;
-    final LatLng? latLng = parseLatLng(place);
-    if (latLng == null) return null;
+  return places
+      .asMap()
+      .entries
+      .map((entry) {
+        final index = entry.key;
+        final place = entry.value;
+        final LatLng? latLng = parseLatLng(place);
+        if (latLng == null) return null;
 
-    return Marker(
-      markerId: MarkerId(place['id'] ?? '${latLng.latitude}_${latLng.longitude}_${place['title']}'),
-      icon: icon, 
-      position: latLng,
-      infoWindow: InfoWindow(title: '${index + 1}. ${place['title'] ?? ''}'),
-      onTap: () {
-        onTap(place);
-        final idx = places.indexWhere(
-          (p) =>
-              (p['id'] != null && p['id'] == place['id']) ||
-              (p['title'] == place['title'] &&
-                  p['lat'] == place['lat'] &&
-                  p['lng'] == place['lng']),
+        return Marker(
+          markerId: MarkerId(
+            place['id'] ??
+                '${latLng.latitude}_${latLng.longitude}_${place['title']}',
+          ),
+          icon: icon,
+          position: latLng,
+          infoWindow: InfoWindow(
+            title: '${index + 1}. ${place['title'] ?? ''}',
+          ),
+          onTap: () {
+            onTap(place);
+            final idx = places.indexWhere(
+              (p) =>
+                  (p['id'] != null && p['id'] == place['id']) ||
+                  (p['title'] == place['title'] &&
+                      p['lat'] == place['lat'] &&
+                      p['lng'] == place['lng']),
+            );
+            if (idx != -1) {
+              if (animateToPage != null) {
+                animateToPage(index);
+              }
+              onPageChanged(idx);
+            }
+          },
         );
-        if (idx != -1) {
-          animateToPage(idx);
-          onPageChanged(idx);
-        }
-      },
-    );
-  }).whereType<Marker>().toSet();
+      })
+      .whereType<Marker>()
+      .toSet();
 }
+
 /// Day 키 값을 기반으로 탭 라벨 문자열을 생성합니다.
 String getDisplayDayTab(String key) {
   final num = int.tryParse(key.replaceAll(RegExp(r'[^0-9]'), '')) ?? 0;

--- a/lib/viewmodels/plan/map_view_model.dart
+++ b/lib/viewmodels/plan/map_view_model.dart
@@ -1,11 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:travel_muse_app/models/home/home_place.dart';
 import 'package:travel_muse_app/models/plan/map_state.dart';
 import 'package:travel_muse_app/repositories/plan/map_repository.dart';
 import 'package:travel_muse_app/utills/latlng_helper.dart';
 import 'package:travel_muse_app/utills/map_utils.dart';
 import 'package:travel_muse_app/utills/marker_helper.dart';
+import 'package:travel_muse_app/views/home/recommended_place/recommended_place_detail_page.dart';
+import 'package:travel_muse_app/views/home/recommended_place/recommended_place_detail_sheet.dart';
 
 class MapViewModel extends StateNotifier<MapState> {
   MapViewModel(this._repository) : super(MapState(dayPlaces: {})) {
@@ -117,18 +120,64 @@ class MapViewModel extends StateNotifier<MapState> {
     required String selectedDayKey,
     required Function(Map<String, dynamic>) onTap,
     required Function(int) onPageChanged,
+    bool isSelectMode = false, // 선택 모드 여부
+    BuildContext? context, // 디테일 바텀시트 띄우기용 context
   }) {
     return createMarkers(
       places: places,
       icon: _currentIcon,
-      onTap: onTap,
+
+      // onTap 로직만 수정
+      onTap: (place) async {
+        onTap(place);
+
+        if (isSelectMode && context != null) {
+          // 바텀시트 띄우고 결과 리턴 기다림
+          final result = await showModalBottomSheet(
+            context: context,
+            isScrollControlled: true,
+            backgroundColor: Colors.transparent,
+            builder: (_) {
+              return DraggableScrollableSheet(
+                initialChildSize: 0.6,
+                minChildSize: 0.4,
+                maxChildSize: 0.95,
+                expand: false,
+                builder: (context, scrollController) {
+                  return Container(
+                    decoration: const BoxDecoration(
+                      color: Colors.white,
+                      borderRadius: BorderRadius.vertical(
+                        top: Radius.circular(16),
+                      ),
+                    ),
+                    child: RecommendedPlaceDetailSheet(
+                      place: HomePlace.fromMap(place),
+                      scrollController: scrollController,
+                    ),
+                  );
+                },
+              );
+            },
+          );
+
+          // 사용자가 '선택하기' 눌렀을 경우 글작성 페이지로 값 넘김
+          if (result != null && context.mounted) {
+            Navigator.pop(context, result);
+          }
+        }
+      },
+
       onPageChanged: onPageChanged,
+
       animateToPage:
-          (idx) => getPageController(selectedDayKey).animateToPage(
-            idx,
-            duration: const Duration(milliseconds: 300),
-            curve: Curves.easeInOut,
-          ),
+          isSelectMode
+              ? null // 선택 모드일 땐 animate 안 함
+              : (idx) => getPageController(selectedDayKey).animateToPage(
+                idx,
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.easeInOut,
+              ),
     );
   }
 
@@ -142,7 +191,7 @@ class MapViewModel extends StateNotifier<MapState> {
     return extractLatLngs(getAllPlaces());
   }
 
-//전체 마커 반환
+  //전체 마커 반환
   Set<Marker> getAllMarkers({
     required Function(Map<String, dynamic>) onTap,
     required Function(int) onPageChanged,
@@ -155,6 +204,30 @@ class MapViewModel extends StateNotifier<MapState> {
       animateToPage: (idx) {
         // 전체 탭은 Carousel 안 보이게 할 수도 있음
       },
+    );
+  }
+
+  void setDummyDayPlaces() {
+    state = state.copyWith(
+      dayPlaces: {
+        'select': [], // 아무 장소도 없는 하나의 날짜 키
+      },
+    );
+  }
+
+  void setDayPlacesForSelectMode(List<Map<String, dynamic>> places) {
+    final convertedPlaces =
+        places.map((e) {
+          return e.map((key, value) => MapEntry(key, value.toString()));
+        }).toList();
+
+    final newDayPlaces = Map<String, List<Map<String, String>>>.from(
+      state.dayPlaces,
+    )..['select'] = convertedPlaces;
+
+    state = state.copyWith(
+      dayPlaces: newDayPlaces,
+      selectedPlace: convertedPlaces.isNotEmpty ? convertedPlaces.first : null,
     );
   }
 }

--- a/lib/viewmodels/plan/map_view_model.dart
+++ b/lib/viewmodels/plan/map_view_model.dart
@@ -4,6 +4,7 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:travel_muse_app/models/home/home_place.dart';
 import 'package:travel_muse_app/models/plan/map_state.dart';
 import 'package:travel_muse_app/repositories/plan/map_repository.dart';
+import 'package:travel_muse_app/services/plan/place_search_service.dart';
 import 'package:travel_muse_app/utills/latlng_helper.dart';
 import 'package:travel_muse_app/utills/map_utils.dart';
 import 'package:travel_muse_app/utills/marker_helper.dart';
@@ -128,43 +129,44 @@ class MapViewModel extends StateNotifier<MapState> {
       icon: _currentIcon,
 
       // onTap 로직만 수정
-      onTap: (place) async {
+      onTap: (place) {
         onTap(place);
 
         if (isSelectMode && context != null) {
-          // 바텀시트 띄우고 결과 리턴 기다림
-          final result = await showModalBottomSheet(
-            context: context,
-            isScrollControlled: true,
-            backgroundColor: Colors.transparent,
-            builder: (_) {
-              return DraggableScrollableSheet(
-                initialChildSize: 0.6,
-                minChildSize: 0.4,
-                maxChildSize: 0.95,
-                expand: false,
-                builder: (context, scrollController) {
-                  return Container(
-                    decoration: const BoxDecoration(
-                      color: Colors.white,
-                      borderRadius: BorderRadius.vertical(
-                        top: Radius.circular(16),
+          Future.microtask(() async {
+            final result = await showModalBottomSheet(
+              // ignore: use_build_context_synchronously
+              context: context,
+              isScrollControlled: true,
+              backgroundColor: Colors.transparent,
+              builder: (_) {
+                return DraggableScrollableSheet(
+                  initialChildSize: 0.6,
+                  minChildSize: 0.4,
+                  maxChildSize: 0.95,
+                  expand: false,
+                  builder: (context, scrollController) {
+                    return Container(
+                      decoration: const BoxDecoration(
+                        color: Colors.white,
+                        borderRadius: BorderRadius.vertical(
+                          top: Radius.circular(16),
+                        ),
                       ),
-                    ),
-                    child: RecommendedPlaceDetailSheet(
-                      place: HomePlace.fromMap(place),
-                      scrollController: scrollController,
-                    ),
-                  );
-                },
-              );
-            },
-          );
+                      child: RecommendedPlaceDetailSheet(
+                        place: HomePlace.fromMap(place),
+                        scrollController: scrollController,
+                      ),
+                    );
+                  },
+                );
+              },
+            );
 
-          // 사용자가 '선택하기' 눌렀을 경우 글작성 페이지로 값 넘김
-          if (result != null && context.mounted) {
-            Navigator.pop(context, result);
-          }
+            if (result != null && context.mounted) {
+              Navigator.pop(context, result);
+            }
+          });
         }
       },
 
@@ -229,5 +231,32 @@ class MapViewModel extends StateNotifier<MapState> {
       dayPlaces: newDayPlaces,
       selectedPlace: convertedPlaces.isNotEmpty ? convertedPlaces.first : null,
     );
+  }
+
+  Future<void> moveCameraToPlace({
+    required GoogleMapController mapController,
+    required String query,
+    required PlaceSearchService placeService,
+  }) async {
+    try {
+      final results = await placeService.search(query);
+      if (results.isEmpty) return;
+
+      final first = results.first;
+      final latLng = LatLng(first.latitude, first.longitude);
+
+      // 지도 카메라 이동
+      await mapController.animateCamera(CameraUpdate.newLatLngZoom(latLng, 15));
+
+      // 선택된 장소 상태에 반영
+      selectPlace({
+        'title': first.name,
+        'lat': first.latitude,
+        'lng': first.longitude,
+        'address': first.address,
+      });
+    } catch (e) {
+      debugPrint('❌ moveCameraToPlace 실패: $e');
+    }
   }
 }

--- a/lib/viewmodels/plan/search_view_model.dart
+++ b/lib/viewmodels/plan/search_view_model.dart
@@ -1,11 +1,13 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/models/plan/place.dart';
+import 'package:travel_muse_app/providers/plan/schedule/map_provider.dart';
 import 'package:travel_muse_app/services/plan/nearby_place_service.dart';
 import 'package:travel_muse_app/services/plan/place_search_service.dart';
 
 class SearchViewModel extends StateNotifier<List<Map<String, String>>> {
-  SearchViewModel(this._placeService, this._nearbyService) : super([]);
-
+  SearchViewModel(this.ref, this._placeService, this._nearbyService)
+    : super([]);
+  final Ref ref;
   final PlaceSearchService _placeService;
   final NearbyPlaceService _nearbyService;
 
@@ -18,6 +20,13 @@ class SearchViewModel extends StateNotifier<List<Map<String, String>>> {
       final places = await _fetchPlaces(query: query, region: region);
       final results = await _mapPlacesToViewData(places);
       state = results;
+
+      // 지도 마커 반영
+      ref
+          .read(mapViewModelProvider.notifier)
+          .setDayPlacesForSelectMode(
+            results.map((e) => e as Map<String, dynamic>).toList(),
+          );
     } catch (_) {
       state = [];
     }
@@ -63,7 +72,7 @@ class SearchViewModel extends StateNotifier<List<Map<String, String>>> {
         return {
           'title': p.name,
           'subtitle': '${p.city} ${p.district} • ${p.category}',
-          'address':p.address,
+          'address': p.address,
           'image': thumb ?? defaultImage,
           'lat': p.latitude.toString(),
           'lng': p.longitude.toString(),

--- a/lib/viewmodels/post/post_view_model.dart
+++ b/lib/viewmodels/post/post_view_model.dart
@@ -15,6 +15,7 @@ class PostViewModel extends StateNotifier<AsyncValue<void>> {
     required String content,
     required List<String> imageUrls,
     required List<String> tags,
+    Map<String, dynamic>? place,
   }) async {
     state = const AsyncLoading();
     try {
@@ -35,6 +36,7 @@ class PostViewModel extends StateNotifier<AsyncValue<void>> {
         isDeleted: false,
         isReposted: false,
         reportCount: 0,
+        place: place,
       );
 
       await _repository.createPost(post);
@@ -51,10 +53,18 @@ class PostViewModel extends StateNotifier<AsyncValue<void>> {
     required String content,
     required List<String> imageUrls,
     required List<String> tags,
+    Map<String, dynamic>? place,
   }) async {
     state = const AsyncLoading();
     try {
-      await _repository.updatePost(postId, title, content, imageUrls, tags);
+      await _repository.updatePost(
+        postId,
+        title,
+        content,
+        imageUrls,
+        tags,
+        place,
+      );
       state = const AsyncData(null);
     } catch (e, st) {
       state = AsyncError(e, st);
@@ -89,6 +99,7 @@ class PostViewModel extends StateNotifier<AsyncValue<void>> {
     required String content,
     required List<String> imagePaths,
     required List<String> tags,
+    Map<String, dynamic>? place,
   }) async {
     state = const AsyncLoading();
     try {
@@ -101,6 +112,7 @@ class PostViewModel extends StateNotifier<AsyncValue<void>> {
           content: content,
           imageUrls: imageUrls,
           tags: tags,
+          place: place,
         );
       } else {
         await createPost(
@@ -108,6 +120,7 @@ class PostViewModel extends StateNotifier<AsyncValue<void>> {
           content: content,
           imageUrls: imageUrls,
           tags: tags,
+          place: place,
         );
       }
     } catch (e, st) {

--- a/lib/views/home/recommended_place/recommended_place_detail_page.dart
+++ b/lib/views/home/recommended_place/recommended_place_detail_page.dart
@@ -42,7 +42,13 @@ class _RecommendedPlaceDetailPageState
                 color: AppColors.grey[500],
                 size: 24,
               ),
-              onPressed: () => Navigator.pop(context),
+              onPressed:
+                  () => Navigator.pop(context, {
+                    'title': place.title,
+                    'lat': place.latLng.latitude,
+                    'lng': place.latLng.longitude,
+                    'address': place.address,
+                  }),
             ),
             const SizedBox(width: 4),
             Text(

--- a/lib/views/home/recommended_place/recommended_place_detail_sheet.dart
+++ b/lib/views/home/recommended_place/recommended_place_detail_sheet.dart
@@ -1,13 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/models/home/home_place.dart';
-import 'package:travel_muse_app/views/home/recommended_place/widgets/action_button_row.dart';
 import 'package:travel_muse_app/views/home/recommended_place/widgets/image_slider.dart';
 import 'package:travel_muse_app/views/home/recommended_place/widgets/location_row.dart';
 import 'package:travel_muse_app/views/home/recommended_place/widgets/place_description.dart';
 import 'package:travel_muse_app/views/home/recommended_place/widgets/place_info_section.dart';
-import 'package:travel_muse_app/views/home/recommended_place/widgets/place_map_view.dart';
-import 'package:travel_muse_app/views/home/recommended_place/widgets/place_stats_row.dart';
 
 class RecommendedPlaceDetailSheet extends StatefulWidget {
   const RecommendedPlaceDetailSheet({

--- a/lib/views/home/recommended_place/recommended_place_detail_sheet.dart
+++ b/lib/views/home/recommended_place/recommended_place_detail_sheet.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/models/home/home_place.dart';
+import 'package:travel_muse_app/views/home/recommended_place/widgets/action_button_row.dart';
+import 'package:travel_muse_app/views/home/recommended_place/widgets/image_slider.dart';
+import 'package:travel_muse_app/views/home/recommended_place/widgets/location_row.dart';
+import 'package:travel_muse_app/views/home/recommended_place/widgets/place_description.dart';
+import 'package:travel_muse_app/views/home/recommended_place/widgets/place_info_section.dart';
+import 'package:travel_muse_app/views/home/recommended_place/widgets/place_map_view.dart';
+import 'package:travel_muse_app/views/home/recommended_place/widgets/place_stats_row.dart';
+
+class RecommendedPlaceDetailSheet extends StatefulWidget {
+  const RecommendedPlaceDetailSheet({
+    super.key,
+    required this.place,
+    this.scrollController,
+  });
+
+  final HomePlace place;
+  final ScrollController? scrollController;
+
+  @override
+  State<RecommendedPlaceDetailSheet> createState() =>
+      _RecommendedPlaceDetailSheetState();
+}
+
+class _RecommendedPlaceDetailSheetState
+    extends State<RecommendedPlaceDetailSheet> {
+  int _currentPage = 0;
+  final PageController _pageController = PageController();
+
+  @override
+  Widget build(BuildContext context) {
+    final place = widget.place;
+    final bottomPadding = MediaQuery.of(context).padding.bottom;
+
+    return Stack(
+      children: [
+        // 스크롤 가능한 컨텐츠
+        Padding(
+          padding: EdgeInsets.only(bottom: 80 + bottomPadding),
+          child: SingleChildScrollView(
+            controller: widget.scrollController,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // 닫기 버튼 + 제목
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      place.title,
+                      style: const TextStyle(
+                        fontSize: 20,
+                        fontWeight: FontWeight.w700,
+                        color: AppColors.black,
+                      ),
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.close, color: Colors.grey),
+                      onPressed: () => Navigator.pop(context),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+
+                // 이미지, 설명 등
+                ImageSlider(
+                  imageUrls: [place.thumbnail],
+                  currentPage: _currentPage,
+                  pageController: _pageController,
+                  onPageChanged:
+                      (index) => setState(() => _currentPage = index),
+                ),
+                const SizedBox(height: 16),
+                LocationRow(place: place),
+                const SizedBox(height: 24),
+                PlaceDescription(),
+                const SizedBox(height: 24),
+                const SizedBox(height: 16),
+                PlaceInfoSection(place: place),
+                const SizedBox(height: 80),
+              ],
+            ),
+          ),
+        ),
+
+        // 하단 고정된 버튼
+        Positioned(
+          left: 16,
+          right: 16,
+          bottom: 16 + bottomPadding,
+          child: ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.primary[300],
+              foregroundColor: Colors.white,
+              minimumSize: const Size.fromHeight(50),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+            ),
+            onPressed: () {
+              Navigator.pop(context, {
+                'title': place.title,
+                'lat': place.latLng.latitude,
+                'lng': place.latLng.longitude,
+                'address': place.address,
+              });
+            },
+            child: const Text('선택하기', style: TextStyle(fontSize: 16)),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/views/home/recommended_place/widgets/location_row.dart
+++ b/lib/views/home/recommended_place/widgets/location_row.dart
@@ -14,7 +14,7 @@ class LocationRow extends StatelessWidget {
         const SizedBox(width: 4),
         Expanded(
           child: Text(
-            place.subtitle,
+            place.address,
             style: const TextStyle(color: Colors.grey),
             overflow: TextOverflow.ellipsis,
           ),

--- a/lib/views/home/recommended_place/widgets/place_info_section.dart
+++ b/lib/views/home/recommended_place/widgets/place_info_section.dart
@@ -15,8 +15,8 @@ class PlaceInfoSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (place.subtitle.isNotEmpty)
-          Text('주소: ${place.subtitle}', style: theme.bodyMedium),
+        if (place.address.isNotEmpty)
+          Text('주소: ${place.address}', style: theme.bodyMedium),
         const SizedBox(height: 4),
         if (place.phone != null && place.phone!.isNotEmpty)
           Text('전화: ${place.phone}', style: theme.bodyMedium),

--- a/lib/views/plan/location/map_page.dart
+++ b/lib/views/plan/location/map_page.dart
@@ -3,16 +3,19 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/providers/plan/schedule/map_provider.dart';
+import 'package:travel_muse_app/providers/plan/schedule/search_provider.dart';
 import 'package:travel_muse_app/utills/map_utils.dart';
 import 'package:travel_muse_app/viewmodels/plan/map_view_model.dart';
 import 'package:travel_muse_app/views/plan/location/widgets/day_tab_bar.dart';
 import 'package:travel_muse_app/views/plan/location/widgets/map_display.dart';
 import 'package:travel_muse_app/views/plan/location/widgets/map_page_app_bar.dart';
 import 'package:travel_muse_app/views/plan/location/widgets/place_carousel.dart';
+import 'package:travel_muse_app/views/plan/location/widgets/search_input_field.dart';
 
 class MapPage extends ConsumerStatefulWidget {
-  const MapPage({super.key, required this.planId});
+  const MapPage({super.key, required this.planId, this.isSelectMode = false});
   final String planId;
+  final bool isSelectMode;
 
   @override
   ConsumerState<MapPage> createState() => _MapPageState();
@@ -22,6 +25,7 @@ class _MapPageState extends ConsumerState<MapPage>
     with TickerProviderStateMixin {
   GoogleMapController? _mapController;
   bool _cameraMoved = false;
+  bool get isSelectMode => widget.planId == 'place-select-mode';
   LatLng _initialLatLng = const LatLng(33.4996, 126.5312);
 
   late final MapViewModel _viewModel;
@@ -58,6 +62,13 @@ class _MapPageState extends ConsumerState<MapPage>
 
   Future<void> initializeControllers() async {
     if (!mounted) return;
+    if (isSelectMode) {
+      ref.read(mapViewModelProvider.notifier).setDummyDayPlaces();
+      _tabController = TabController(length: 1, vsync: this);
+      setState(() {});
+      return;
+    }
+
     await _viewModel.loadPlanAndRoute(widget.planId, this);
 
     final dayKeys = ref.read(mapViewModelProvider).dayPlaces.keys.toList();
@@ -92,10 +103,15 @@ class _MapPageState extends ConsumerState<MapPage>
   }
 
   void _initCameraPosition(List<Map<String, dynamic>> selectedPlaces) {
-    if (!_cameraMoved && selectedPlaces.isNotEmpty) {
-      final initial = _viewModel.getInitialLatLng(selectedPlaces);
-      if (initial != null) {
-        _initialLatLng = initial;
+    if (!_cameraMoved) {
+      if (selectedPlaces.isNotEmpty) {
+        final initial = _viewModel.getInitialLatLng(selectedPlaces);
+        if (initial != null) {
+          _initialLatLng = initial;
+        }
+      } else {
+        /// 장소 없을 때 기본 좌표
+        _initialLatLng = const LatLng(37.5665, 126.9780); // 서울 시청
       }
     }
   }
@@ -112,7 +128,7 @@ class _MapPageState extends ConsumerState<MapPage>
     final index = _tabController!.index;
     List<Map<String, dynamic>> selectedPlaces;
     if (index == 0) {
-      selectedPlaces = _viewModel.getAllPlaces(); 
+      selectedPlaces = _viewModel.getAllPlaces();
     } else {
       selectedPlaces = mapState.dayPlaces[dayKeys[index - 1]] ?? [];
     }
@@ -129,13 +145,17 @@ class _MapPageState extends ConsumerState<MapPage>
           setState(() {});
         }
       },
+      isSelectMode: isSelectMode,
+      context: context,
     );
     final displayDayTabs = ['All', ...dayKeys.map(getDisplayDayTab)];
     return Scaffold(
       appBar: MapPageAppBar(),
-      body: Column(
+
+      body: Stack(
         children: [
-          Expanded(
+          /// 1. 지도는 전체를 꽉 채움
+          Positioned.fill(
             child: MapDisplay(
               initialLatLng: _initialLatLng,
               points: points,
@@ -154,22 +174,55 @@ class _MapPageState extends ConsumerState<MapPage>
               },
             ),
           ),
-          SizedBox(
-            height: screenHeight * 0.25,
-            child: Column(
-              children: [
-                DayTabBar(controller: _tabController!, days: displayDayTabs),
-                Expanded(
-                  child: PlaceCarousel(
-                    dayKeys: dayKeys,
-                    mapState: mapState,
-                    viewModel: _viewModel,
-                    selectedPlace: mapState.selectedPlace,
-                    mapController: _mapController,
-                    tabController: _tabController!,
-                  ),
-                ),
-              ],
+
+          /// 2. 검색창은 상단에 고정 (선택모드일 때만)
+          if (isSelectMode)
+            Positioned(
+              top: 16,
+              left: 16,
+              right: 16,
+              child: SearchInputField(
+                onSearch:
+                    (query) => ref
+                        .read(searchViewModelProvider.notifier)
+                        .search(query),
+              ),
+            ),
+
+          /// 3. 하단 영역: DayTabBar 또는 PlaceCarousel
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: SizedBox(
+              height: MediaQuery.of(context).size.height * 0.25,
+              child: Column(
+                children: [
+                  if (!isSelectMode)
+                    Container(
+                      color: Colors.white,
+                      child: DayTabBar(
+                        controller: _tabController!,
+                        days: displayDayTabs,
+                      ),
+                    ),
+                  if (!isSelectMode)
+                    Expanded(
+                      child: Container(
+                        color: Colors.white,
+                        child: PlaceCarousel(
+                          dayKeys: dayKeys,
+                          mapState: mapState,
+                          viewModel: _viewModel,
+                          selectedPlace: mapState.selectedPlace,
+                          mapController: _mapController,
+                          tabController: _tabController!,
+                          isSelectMode: widget.isSelectMode,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
             ),
           ),
         ],

--- a/lib/views/plan/location/map_page.dart
+++ b/lib/views/plan/location/map_page.dart
@@ -3,20 +3,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/providers/plan/schedule/map_provider.dart';
-import 'package:travel_muse_app/providers/plan/schedule/search_provider.dart';
 import 'package:travel_muse_app/utills/map_utils.dart';
 import 'package:travel_muse_app/viewmodels/plan/map_view_model.dart';
 import 'package:travel_muse_app/views/plan/location/widgets/day_tab_bar.dart';
 import 'package:travel_muse_app/views/plan/location/widgets/map_display.dart';
 import 'package:travel_muse_app/views/plan/location/widgets/map_page_app_bar.dart';
 import 'package:travel_muse_app/views/plan/location/widgets/place_carousel.dart';
-import 'package:travel_muse_app/views/plan/location/widgets/search_input_field.dart';
 
 class MapPage extends ConsumerStatefulWidget {
-  const MapPage({super.key, required this.planId, this.isSelectMode = false});
+  const MapPage({super.key, required this.planId});
   final String planId;
-  final bool isSelectMode;
-
   @override
   ConsumerState<MapPage> createState() => _MapPageState();
 }
@@ -25,24 +21,17 @@ class _MapPageState extends ConsumerState<MapPage>
     with TickerProviderStateMixin {
   GoogleMapController? _mapController;
   bool _cameraMoved = false;
-  bool get isSelectMode => widget.planId == 'place-select-mode';
   LatLng _initialLatLng = const LatLng(33.4996, 126.5312);
-
   late final MapViewModel _viewModel;
   TabController? _tabController;
-
   void _onTabChanged() {
     if (!mounted) return;
     final mapState = ref.read(mapViewModelProvider);
     final dayKeys = mapState.dayPlaces.keys.toList();
-
     if (_tabController == null || dayKeys.isEmpty) return;
-
     if (!_tabController!.indexIsChanging) {
       setState(() {});
-
       final index = _tabController!.index;
-
       if (index == 0) {
         final allPlaces = _viewModel.getAllPlaces();
         _viewModel.moveCameraToFitAll(_mapController, allPlaces);
@@ -62,21 +51,11 @@ class _MapPageState extends ConsumerState<MapPage>
 
   Future<void> initializeControllers() async {
     if (!mounted) return;
-    if (isSelectMode) {
-      ref.read(mapViewModelProvider.notifier).setDummyDayPlaces();
-      _tabController = TabController(length: 1, vsync: this);
-      setState(() {});
-      return;
-    }
-
     await _viewModel.loadPlanAndRoute(widget.planId, this);
-
     final dayKeys = ref.read(mapViewModelProvider).dayPlaces.keys.toList();
     if (dayKeys.isEmpty) return;
-
     _tabController = TabController(length: dayKeys.length + 1, vsync: this);
     _tabController!.addListener(_onTabChanged);
-
     setState(() {});
   }
 
@@ -84,7 +63,6 @@ class _MapPageState extends ConsumerState<MapPage>
   void initState() {
     super.initState();
     _viewModel = ref.read(mapViewModelProvider.notifier);
-
     WidgetsBinding.instance.addPostFrameCallback((_) {
       initializeControllers();
     });
@@ -97,21 +75,16 @@ class _MapPageState extends ConsumerState<MapPage>
       _tabController?.dispose();
       _viewModel.disposeControllers();
     } catch (e) {
-      debugPrint('💥 dispose error: $e');
+      debugPrint(':쾅: dispose error: $e');
     }
     super.dispose();
   }
 
   void _initCameraPosition(List<Map<String, dynamic>> selectedPlaces) {
-    if (!_cameraMoved) {
-      if (selectedPlaces.isNotEmpty) {
-        final initial = _viewModel.getInitialLatLng(selectedPlaces);
-        if (initial != null) {
-          _initialLatLng = initial;
-        }
-      } else {
-        /// 장소 없을 때 기본 좌표
-        _initialLatLng = const LatLng(37.5665, 126.9780); // 서울 시청
+    if (!_cameraMoved && selectedPlaces.isNotEmpty) {
+      final initial = _viewModel.getInitialLatLng(selectedPlaces);
+      if (initial != null) {
+        _initialLatLng = initial;
       }
     }
   }
@@ -124,7 +97,6 @@ class _MapPageState extends ConsumerState<MapPage>
     if (_isLoading(_tabController, dayKeys)) {
       return const Scaffold(body: Center(child: CircularProgressIndicator()));
     }
-
     final index = _tabController!.index;
     List<Map<String, dynamic>> selectedPlaces;
     if (index == 0) {
@@ -132,9 +104,7 @@ class _MapPageState extends ConsumerState<MapPage>
     } else {
       selectedPlaces = mapState.dayPlaces[dayKeys[index - 1]] ?? [];
     }
-
     _initCameraPosition(selectedPlaces);
-
     final points = _viewModel.extractLatLngs(selectedPlaces);
     final markers = _viewModel.getMarkers(
       places: selectedPlaces,
@@ -145,17 +115,13 @@ class _MapPageState extends ConsumerState<MapPage>
           setState(() {});
         }
       },
-      isSelectMode: isSelectMode,
-      context: context,
     );
     final displayDayTabs = ['All', ...dayKeys.map(getDisplayDayTab)];
     return Scaffold(
       appBar: MapPageAppBar(),
-
-      body: Stack(
+      body: Column(
         children: [
-          /// 1. 지도는 전체를 꽉 채움
-          Positioned.fill(
+          Expanded(
             child: MapDisplay(
               initialLatLng: _initialLatLng,
               points: points,
@@ -174,55 +140,23 @@ class _MapPageState extends ConsumerState<MapPage>
               },
             ),
           ),
-
-          /// 2. 검색창은 상단에 고정 (선택모드일 때만)
-          if (isSelectMode)
-            Positioned(
-              top: 16,
-              left: 16,
-              right: 16,
-              child: SearchInputField(
-                onSearch:
-                    (query) => ref
-                        .read(searchViewModelProvider.notifier)
-                        .search(query),
-              ),
-            ),
-
-          /// 3. 하단 영역: DayTabBar 또는 PlaceCarousel
-          Positioned(
-            left: 0,
-            right: 0,
-            bottom: 0,
-            child: SizedBox(
-              height: MediaQuery.of(context).size.height * 0.25,
-              child: Column(
-                children: [
-                  if (!isSelectMode)
-                    Container(
-                      color: Colors.white,
-                      child: DayTabBar(
-                        controller: _tabController!,
-                        days: displayDayTabs,
-                      ),
-                    ),
-                  if (!isSelectMode)
-                    Expanded(
-                      child: Container(
-                        color: Colors.white,
-                        child: PlaceCarousel(
-                          dayKeys: dayKeys,
-                          mapState: mapState,
-                          viewModel: _viewModel,
-                          selectedPlace: mapState.selectedPlace,
-                          mapController: _mapController,
-                          tabController: _tabController!,
-                          isSelectMode: widget.isSelectMode,
-                        ),
-                      ),
-                    ),
-                ],
-              ),
+          SizedBox(
+            height: screenHeight * 0.25,
+            child: Column(
+              children: [
+                DayTabBar(controller: _tabController!, days: displayDayTabs),
+                Expanded(
+                  child: PlaceCarousel(
+                    dayKeys: dayKeys,
+                    mapState: mapState,
+                    viewModel: _viewModel,
+                    selectedPlace: mapState.selectedPlace,
+                    mapController: _mapController,
+                    tabController: _tabController!,
+                    isSelectMode: false,
+                  ),
+                ),
+              ],
             ),
           ),
         ],

--- a/lib/views/plan/location/select_place_map_page.dart
+++ b/lib/views/plan/location/select_place_map_page.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:travel_muse_app/providers/plan/schedule/map_provider.dart';
+import 'package:travel_muse_app/providers/plan/schedule/place_search_service_provider.dart';
+import 'package:travel_muse_app/providers/plan/schedule/search_provider.dart';
+import 'package:travel_muse_app/viewmodels/plan/map_view_model.dart';
+import 'package:travel_muse_app/views/plan/location/widgets/map_display.dart';
+import 'package:travel_muse_app/views/plan/location/widgets/map_page_app_bar.dart';
+import 'package:travel_muse_app/views/plan/location/widgets/search_input_field.dart';
+
+class SelectPlaceMapPage extends ConsumerStatefulWidget {
+  const SelectPlaceMapPage({
+    super.key,
+    required this.planId,
+    required this.isSelectMode,
+  });
+
+  final String planId;
+  final bool isSelectMode;
+
+  @override
+  ConsumerState<SelectPlaceMapPage> createState() => _SelectPlaceMapPageState();
+}
+
+class _SelectPlaceMapPageState extends ConsumerState<SelectPlaceMapPage> {
+  GoogleMapController? _mapController;
+  bool _cameraMoved = false;
+  LatLng _initialLatLng = const LatLng(37.5665, 126.9780); // 서울시청
+
+  late final MapViewModel _viewModel;
+
+  @override
+  void initState() {
+    super.initState();
+    _viewModel = ref.read(mapViewModelProvider.notifier);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _viewModel.setDummyDayPlaces();
+    });
+  }
+
+  @override
+  void dispose() {
+    try {
+      _viewModel.disposeControllers();
+    } catch (e) {
+      debugPrint('💥 dispose error: $e');
+    }
+    super.dispose();
+  }
+
+  void _initCameraPosition(List<Map<String, dynamic>> places) {
+    if (!_cameraMoved && places.isNotEmpty) {
+      final latLng = _viewModel.getInitialLatLng(places);
+      if (latLng != null) {
+        _initialLatLng = latLng;
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final mapState = ref.watch(mapViewModelProvider);
+    final places = mapState.dayPlaces['select'] ?? [];
+    _initCameraPosition(places);
+
+    final points = _viewModel.extractLatLngs(places);
+    final markers = _viewModel.getMarkers(
+      places: places,
+      selectedDayKey: 'select',
+      isSelectMode: true,
+      context: context,
+      onTap: (place) => _viewModel.selectPlace(place),
+      onPageChanged: (_) {},
+    );
+
+    return Scaffold(
+      appBar: MapPageAppBar(),
+      body: Stack(
+        children: [
+          /// 지도 전체 표시
+          Positioned.fill(
+            child: MapDisplay(
+              initialLatLng: _initialLatLng,
+              points: points,
+              markers: markers,
+              onMapCreated: (controller) {
+                _mapController = controller;
+                if (!_cameraMoved && places.isNotEmpty) {
+                  Future.delayed(const Duration(milliseconds: 300), () {
+                    _viewModel.moveCameraToFitAll(_mapController, places);
+                    _cameraMoved = true;
+                  });
+                }
+              },
+            ),
+          ),
+
+          /// 검색창 고정
+          Positioned(
+            top: 16,
+            left: 16,
+            right: 16,
+            child: SearchInputField(
+              onSearch: (query) async {
+                final viewModel = ref.read(mapViewModelProvider.notifier);
+                final placeService = ref.read(placeSearchServiceProvider);
+                final controller = _mapController;
+
+                if (controller != null) {
+                  await viewModel.moveCameraToPlace(
+                    mapController: controller,
+                    query: query,
+                    placeService: placeService,
+                  );
+                }
+
+                // 기존 검색 결과도 그대로 반영
+                await ref.read(searchViewModelProvider.notifier).search(query);
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/plan/location/widgets/place_card.dart
+++ b/lib/views/plan/location/widgets/place_card.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/models/home/home_place.dart';
+import 'package:travel_muse_app/views/home/recommended_place/recommended_place_detail_page.dart';
 
 class PlaceCard extends StatelessWidget {
   const PlaceCard({
@@ -8,11 +10,13 @@ class PlaceCard extends StatelessWidget {
     this.isSelected = false,
     this.onTap,
     super.key,
+    required this.isSelectMode,
   });
 
   final Map<String, dynamic> placeData;
   final bool isSelected;
   final VoidCallback? onTap;
+  final bool isSelectMode;
 
   @override
   Widget build(BuildContext context) {
@@ -21,7 +25,20 @@ class PlaceCard extends StatelessWidget {
     final imageUrl = placeData['image'] ?? '';
 
     return GestureDetector(
-      onTap: onTap,
+      onTap:
+          onTap ??
+          () {
+            ///isSelectMode일 때만 내부에서 push 처리
+            if (isSelectMode) {
+              final homePlace = HomePlace.fromMap(placeData);
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => RecommendedPlaceDetailPage(place: homePlace),
+                ),
+              );
+            }
+          },
       child: Container(
         margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         decoration: BoxDecoration(
@@ -57,29 +74,33 @@ class PlaceCard extends StatelessWidget {
 
             // 텍스트들
             Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Text(
-                    name,
-                    style: const TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w700,
+              child: SizedBox(
+                height: 90,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      name,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w700,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                     ),
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                  const SizedBox(height: 6),
-                  Text(
-                    address,
-                    style: const TextStyle(
-                      fontSize: 16,
-                      color: AppColors.black,
+                    const SizedBox(height: 4),
+                    Text(
+                      address,
+                      style: const TextStyle(
+                        fontSize: 14,
+                        color: AppColors.black,
+                        height: 1.3,
+                      ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
                     ),
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
 
@@ -88,7 +109,7 @@ class PlaceCard extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.all(8.0),
                 child: SvgPicture.asset(
-                  'assets/icons/check-circle.svg', 
+                  'assets/icons/check-circle.svg',
                   width: 28,
                   height: 28,
                 ),

--- a/lib/views/plan/location/widgets/place_carousel.dart
+++ b/lib/views/plan/location/widgets/place_carousel.dart
@@ -16,6 +16,7 @@ class PlaceCarousel extends StatelessWidget {
     required this.tabController,
     required this.selectedPlace,
     required this.mapController,
+    required this.isSelectMode,
   });
 
   final List<String> dayKeys;
@@ -24,6 +25,7 @@ class PlaceCarousel extends StatelessWidget {
   final TabController tabController;
   final Map<String, dynamic>? selectedPlace;
   final GoogleMapController? mapController;
+  final bool isSelectMode;
 
   @override
   Widget build(BuildContext context) {
@@ -56,6 +58,7 @@ class PlaceCarousel extends StatelessWidget {
               child: PlaceCard(
                 placeData: place,
                 isSelected: selectedPlace?['id'] == place['id'],
+                isSelectMode: isSelectMode,
               ),
             );
           },
@@ -90,8 +93,9 @@ class PlaceCarousel extends StatelessWidget {
                     child: PlaceCard(
                       placeData: place,
                       isSelected: selectedPlace?['id'] == place['id'],
+                      isSelectMode: isSelectMode,
                       onTap: () {
-                        final homePlace = HomePlace.fromMap(place); 
+                        final homePlace = HomePlace.fromMap(place);
                         Navigator.push(
                           context,
                           MaterialPageRoute(

--- a/lib/views/plan/location/widgets/search_input_field.dart
+++ b/lib/views/plan/location/widgets/search_input_field.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:travel_muse_app/constants/app_colors.dart';
+
+class SearchInputField extends StatefulWidget {
+  const SearchInputField({
+    super.key,
+    required this.onSearch,
+    this.hintText = '장소를 검색해보세요',
+  });
+  final ValueChanged<String> onSearch;
+  final String hintText;
+
+  @override
+  State<SearchInputField> createState() => _SearchInputFieldState();
+}
+
+class _SearchInputFieldState extends State<SearchInputField> {
+  final TextEditingController _controller = TextEditingController();
+  String _searchText = '';
+
+  void _handleSearch() {
+    if (_searchText.trim().isNotEmpty) {
+      widget.onSearch(_searchText.trim());
+      FocusScope.of(context).unfocus();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+      child: Container(
+        decoration: BoxDecoration(
+          color: AppColors.white,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: TextField(
+          controller: _controller,
+          onChanged: (value) => setState(() => _searchText = value),
+          onSubmitted: (_) => _handleSearch(),
+          textInputAction: TextInputAction.search,
+          decoration: InputDecoration(
+            prefixIcon: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Icon(CupertinoIcons.search),
+            ),
+            hintText: widget.hintText,
+            hintStyle: TextStyle(
+              color: AppColors.grey[400],
+              fontSize: 15,
+              fontFamily: 'Pretendard',
+            ),
+            suffixIcon:
+                _searchText.isNotEmpty
+                    ? IconButton(
+                      icon: Icon(Icons.clear, color: AppColors.grey[400]),
+                      onPressed: () {
+                        _controller.clear();
+                        setState(() => _searchText = '');
+                      },
+                    )
+                    : null,
+            border: InputBorder.none,
+            contentPadding: const EdgeInsets.symmetric(vertical: 14),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/post/post_detail_page.dart
+++ b/lib/views/post/post_detail_page.dart
@@ -1,9 +1,12 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:http/http.dart';
 import 'package:travel_muse_app/models/post/post_model.dart';
 import 'package:travel_muse_app/providers/post/post_provider.dart';
 import 'package:travel_muse_app/views/post/post_write_page.dart';
+import 'package:travel_muse_app/views/post/widgets/detail/place_preview_card.dart';
 import 'package:travel_muse_app/views/post/widgets/detail/post_detail_appbar.dart';
 import 'package:travel_muse_app/views/post/widgets/detail/post_detail_content.dart';
 import 'package:travel_muse_app/views/post/widgets/detail/post_detail_header.dart';
@@ -131,6 +134,15 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
             const SizedBox(height: 16),
             PostDetailImages(images: currentPost.images),
             const SizedBox(height: 16),
+            if (currentPost.place != null)
+              PlacePreviewCard(
+                title: currentPost.place!['title'] ?? '',
+                address: currentPost.place!['address'] ?? '',
+                latLng: LatLng(
+                  (currentPost.place!['lat'] ?? 0).toDouble(),
+                  (currentPost.place!['lng'] ?? 0).toDouble(),
+                ),
+              ),
             PostDetailTagsAndMeta(
               tags: currentPost.tags,
               createdAt: currentPost.createAt.toDate(),

--- a/lib/views/post/post_write_page.dart
+++ b/lib/views/post/post_write_page.dart
@@ -46,14 +46,37 @@ class _PostWritePageState extends ConsumerState<PostWritePage> {
     final picker = ImagePicker();
     final pickedFiles = await picker.pickMultiImage();
 
-    if (pickedFiles.isNotEmpty) {
-      setState(() {
-        imagePaths.addAll(pickedFiles.map((e) => e.path));
-      });
+    if (pickedFiles.isEmpty) return;
+
+    final remaining = 5 - imagePaths.length;
+
+    if (remaining <= 0) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('이미지는 최대 5장까지만 업로드할 수 있어요.')),
+      );
+      return;
+    }
+
+    final addableFiles = pickedFiles.take(remaining).toList();
+
+    setState(() {
+      imagePaths.addAll(addableFiles.map((e) => e.path));
+    });
+
+    if (addableFiles.length < pickedFiles.length) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('최대 5장까지만 업로드할 수 있어요.')));
     }
   }
 
   void _submitPost() async {
+    if (imagePaths.length > 5) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('이미지는 최대 5장까지만 업로드할 수 있어요.')),
+      );
+      return;
+    }
     final titleError = PostValidator.validateTitle(titleController.text);
     final contentError = PostValidator.validateContent(contentController.text);
 
@@ -148,15 +171,40 @@ class _PostWritePageState extends ConsumerState<PostWritePage> {
                         ),
                       ),
                     const SizedBox(height: 16),
-                    if (selectedPlace != null)
-                      PlacePreviewCard(
-                        title: selectedPlace!['title'] ?? '',
-                        address: selectedPlace!['address'] ?? '',
-                        latLng: LatLng(
-                          (selectedPlace!['lat'] as num).toDouble(),
-                          (selectedPlace!['lng'] as num).toDouble(),
-                        ),
+                    if (selectedPlace != null) ...[
+                      Stack(
+                        children: [
+                          PlacePreviewCard(
+                            title: selectedPlace!['title'] ?? '',
+                            address: selectedPlace!['address'] ?? '',
+                            latLng: LatLng(
+                              (selectedPlace!['lat'] as num).toDouble(),
+                              (selectedPlace!['lng'] as num).toDouble(),
+                            ),
+                          ),
+                          Positioned(
+                            top: 8,
+                            right: 8,
+                            child: GestureDetector(
+                              onTap: () {
+                                setState(() {
+                                  selectedPlace = null;
+                                });
+                              },
+                              child: const CircleAvatar(
+                                radius: 14,
+                                backgroundColor: Colors.white,
+                                child: Icon(
+                                  Icons.close,
+                                  size: 18,
+                                  color: Colors.grey,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
                       ),
+                    ],
                   ],
                 ),
               ),
@@ -171,7 +219,7 @@ class _PostWritePageState extends ConsumerState<PostWritePage> {
             if (imagePaths.isNotEmpty) ...[
               const SizedBox(height: 12),
               ImagePreviewList(
-                imagePaths: imagePaths,
+                imagePaths: imagePaths.take(5).toList(),
                 onRemove: (index) => setState(() => imagePaths.removeAt(index)),
               ),
             ],

--- a/lib/views/post/post_write_page.dart
+++ b/lib/views/post/post_write_page.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:travel_muse_app/models/post/post_model.dart';
 import 'package:travel_muse_app/providers/post/post_provider.dart';
 import 'package:travel_muse_app/utills/date_utils.dart';
+import 'package:travel_muse_app/views/post/widgets/detail/place_preview_card.dart';
 import 'package:travel_muse_app/views/post/widgets/write/image_preview_list.dart';
 import 'package:travel_muse_app/views/post/widgets/write/post_action_buttons.dart';
 import 'package:travel_muse_app/views/post/widgets/write/post_location_category.dart';
@@ -22,6 +24,7 @@ class _PostWritePageState extends ConsumerState<PostWritePage> {
   final titleController = TextEditingController();
   final contentController = TextEditingController();
   final List<String> imagePaths = [];
+  Map<String, dynamic>? selectedPlace;
 
   Set<String> selectedTags = {};
   String? titleErrorText;
@@ -35,6 +38,7 @@ class _PostWritePageState extends ConsumerState<PostWritePage> {
       contentController.text = widget.post!.content;
       imagePaths.addAll(widget.post!.images);
       selectedTags = widget.post!.tags.toSet();
+      selectedPlace = widget.post!.place;
     }
   }
 
@@ -69,6 +73,7 @@ class _PostWritePageState extends ConsumerState<PostWritePage> {
       content: contentController.text.trim(),
       imagePaths: imagePaths,
       tags: selectedTags.toList(),
+      place: selectedPlace,
     );
 
     if (mounted) {
@@ -143,6 +148,15 @@ class _PostWritePageState extends ConsumerState<PostWritePage> {
                         ),
                       ),
                     const SizedBox(height: 16),
+                    if (selectedPlace != null)
+                      PlacePreviewCard(
+                        title: selectedPlace!['title'] ?? '',
+                        address: selectedPlace!['address'] ?? '',
+                        latLng: LatLng(
+                          (selectedPlace!['lat'] as num).toDouble(),
+                          (selectedPlace!['lng'] as num).toDouble(),
+                        ),
+                      ),
                   ],
                 ),
               ),
@@ -150,6 +164,8 @@ class _PostWritePageState extends ConsumerState<PostWritePage> {
             PostLocationCategory(
               selectedTags: selectedTags,
               onTagsChanged: (tags) => setState(() => selectedTags = tags),
+              selectedPlace: selectedPlace,
+              onPlaceChanged: (place) => setState(() => selectedPlace = place),
             ),
             const SizedBox(height: 8),
             if (imagePaths.isNotEmpty) ...[

--- a/lib/views/post/widgets/detail/place_preview_card.dart
+++ b/lib/views/post/widgets/detail/place_preview_card.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+class PlacePreviewCard extends StatelessWidget {
+  const PlacePreviewCard({
+    super.key,
+    required this.title,
+    required this.address,
+    required this.latLng,
+  });
+  final String title;
+  final String address;
+  final LatLng latLng;
+
+  @override
+  Widget build(BuildContext context) {
+    final CameraPosition cameraPosition = CameraPosition(
+      target: latLng,
+      zoom: 14,
+    );
+
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      elevation: 2,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            height: 160,
+            child: ClipRRect(
+              borderRadius: const BorderRadius.vertical(
+                top: Radius.circular(12),
+              ),
+              child: GoogleMap(
+                initialCameraPosition: cameraPosition,
+                markers: {
+                  Marker(
+                    markerId: const MarkerId('preview_marker'),
+                    position: latLng,
+                  ),
+                },
+                zoomControlsEnabled: false,
+                myLocationButtonEnabled: false,
+                onTap: (_) {}, // disable interaction
+                liteModeEnabled: true, // for performance
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  address,
+                  style: const TextStyle(fontSize: 14, color: Colors.grey),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/post/widgets/write/post_location_category.dart
+++ b/lib/views/post/widgets/write/post_location_category.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/views/plan/location/map_page.dart';
+import 'package:travel_muse_app/views/plan/location/select_place_map_page.dart';
 import 'package:travel_muse_app/views/post/widgets/write/bottom_sheet_category.dart';
 
 class PostLocationCategory extends StatelessWidget {
@@ -28,7 +29,7 @@ class PostLocationCategory extends StatelessWidget {
               context,
               MaterialPageRoute(
                 builder:
-                    (_) => const MapPage(
+                    (_) => const SelectPlaceMapPage(
                       planId: 'place-select-mode',
                       isSelectMode: true,
                     ),

--- a/lib/views/post/widgets/write/post_location_category.dart
+++ b/lib/views/post/widgets/write/post_location_category.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/plan/location/map_page.dart';
 import 'package:travel_muse_app/views/post/widgets/write/bottom_sheet_category.dart';
 
 class PostLocationCategory extends StatelessWidget {
@@ -6,17 +7,45 @@ class PostLocationCategory extends StatelessWidget {
     super.key,
     required this.selectedTags,
     required this.onTagsChanged,
+    required this.selectedPlace,
+    required this.onPlaceChanged,
   });
 
   final Set<String> selectedTags;
   final ValueChanged<Set<String>> onTagsChanged;
+
+  final Map<String, dynamic>? selectedPlace;
+  final ValueChanged<Map<String, dynamic>>? onPlaceChanged;
 
   @override
   Widget build(BuildContext context) {
     return Column(
       children: [
         // 위치
-        buildItem(Icons.location_on_outlined, '위치 추가하기'),
+        GestureDetector(
+          onTap: () async {
+            final selectedPlace = await Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder:
+                    (_) => const MapPage(
+                      planId: 'place-select-mode',
+                      isSelectMode: true,
+                    ),
+              ),
+            );
+
+            if (selectedPlace != null &&
+                selectedPlace is Map<String, dynamic>) {
+              debugPrint('선택된 위치: ${selectedPlace['address']}');
+              onPlaceChanged?.call(selectedPlace);
+            }
+          },
+          child: buildItem(
+            Icons.location_on_outlined,
+            selectedPlace?['address'] ?? '위치 추가하기',
+          ),
+        ),
 
         // 카테고리
         GestureDetector(


### PR DESCRIPTION
### 🚀: 개요
- 게시글 작성/수정 시 장소 선택 기능 추가
- 선택 모드 기반 지도 조건 분기 로직 적용

### 🚀: 작업 내용
Post 모델에 place 필드 추가 (Firestore 연동 포함)

PostWritePage에서 선택된 장소 저장 기능 구현

PostDetailPage에서 장소 정보 기반 지도 미리보기 (PlacePreviewCard) 표시

지도 페이지(MapPage)에 선택모드 조건 분기 적용

isSelectMode == true일 때만 검색창 표시

하단 DayTabBar는 항상 유지

선택 완료 시 Navigator.pop(context, {...})으로 장소 정보 반환

PlaceCard 오버플로우 이슈 해결 (주소 텍스트 길이 대응)

PostLocationCategory에 장소/카테고리 선택 UI 연동

PlacePreviewCard 생성 및 google_maps_flutter 연동

카카오 키워드 검색 시 지도 카메라 이동 기능 추가

게시글 이미지 업로드 최대 5장 제한 처리

게시글 작성 시 선택된 장소 정보 미리보기 및 삭제 기능 추가

장소 선택을 위한 전용 지도 페이지 (`SelectPlaceMapPage`) 생성

마커 클릭 시 `RecommendedPlaceDetailSheet` 바텀시트 노출

`MapViewModel.getMarkers()` 함수 내 `isSelectMode` 조건 분기 처리

### 📸: 실행 화면
### 📸: 실행 화면
<img src="https://github.com/user-attachments/assets/957f21aa-4534-44a9-b36d-9f253c47343e" width="300" />
<img src="https://github.com/user-attachments/assets/b7452684-9c41-416e-b43a-b900c4477b42" width="300" />
<img src="https://github.com/user-attachments/assets/5a7957cc-8c64-44c2-bbb1-78fc4cc5dfb1" width="300" />
<img src="https://github.com/user-attachments/assets/c29ac6e0-7538-4b7a-8f1d-6a9bf94db2d3" width="300" />


### 🚀: 조정 파일
post_write_page.dart

post_detail_page.dart

post_model.dart

place_preview_card.dart

map_page.dart

search_input_field.dart

recommended_place_detail_sheet.dart

post_location_category.dart

place_card.dart

### 개발 결과
장소 저장 및 지도 미리보기 기능 안정 적용

선택모드 기반 조건 분기 완전 적용

기존 구조 유지하며 최소한의 변경으로 기능 확장 완료

### issue
Closes #198 
