### PR TITLE
[Home] 장소 상세보기 저장 기능(스크랩)

### DIFF
--- a/lib/models/home/home_place.dart
+++ b/lib/models/home/home_place.dart
@@ -61,6 +61,23 @@ class HomePlace {
       distance: map['distance'],
     );
   }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'title': title,
+      'subtitle': subtitle,
+      'address': address,
+      'image': thumbnail,
+      'lat': latLng.latitude,
+      'lng': latLng.longitude,
+      'category': category,
+      'phone': phone,
+      'placeUrl': placeUrl,
+      'isFavorite': isFavorite,
+      'distance': distance,
+    };
+  }
 }
 
 extension PlaceMapping on Place {

--- a/lib/providers/home/scrap_provider.dart
+++ b/lib/providers/home/scrap_provider.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travel_muse_app/models/home/home_place.dart';
+import 'package:travel_muse_app/repositories/home/scrap_repository.dart';
+import 'package:travel_muse_app/viewmodels/home/scrap_view_model.dart';
+import 'package:travel_muse_app/viewmodels/user/scrap_list_view_model.dart';
+
+/// 스크랩 관련 Firebase 통신을 담당
+final scrapRepositoryProvider = Provider((ref) => ScrapRepository());
+
+/// 사용자가 스크랩한 장소들의 ID Set을 관리
+final scrapViewModelProvider =
+    StateNotifierProvider<ScrapViewModel, Set<String>>((ref) {
+  return ScrapViewModel(ref.read(scrapRepositoryProvider));
+});
+
+/// 실제 스크랩된 장소의 상세 정보 리스트를 불러옴
+final scrapListViewModelProvider =
+    StateNotifierProvider<ScrapListViewModel, AsyncValue<List<HomePlace>>>(
+  (ref) => ScrapListViewModel(ref.read(scrapRepositoryProvider)),
+);

--- a/lib/repositories/home/scrap_repository.dart
+++ b/lib/repositories/home/scrap_repository.dart
@@ -1,0 +1,66 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:travel_muse_app/models/home/home_place.dart';
+
+class ScrapRepository {
+  final _firestore = FirebaseFirestore.instance;
+  final _auth = FirebaseAuth.instance;
+
+/// 현재 로그인한 사용자의 스크랩 목록에 장소 데이터를 저장
+  Future<void> saveScrap(HomePlace place) async {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) return;
+
+    await _firestore
+        .collection('appUser')
+        .doc(uid)
+        .collection('scrapped_places')
+        .doc(place.id)
+        .set(place.toMap());
+  }
+
+/// 현재 로그인한 사용자의 스크랩 목록에서 해당 장소 제거
+  Future<void> deleteScrap(String placeId) async {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) return;
+
+    await _firestore
+        .collection('appUser')
+        .doc(uid)
+        .collection('scrapped_places')
+        .doc(placeId)
+        .delete();
+  }
+
+
+/// 현재 사용자가 특정 장소를 스크랩했는지 여부 반환
+  Future<bool> isScrapped(String placeId) async {
+    final uid = _auth.currentUser?.uid;
+    if (uid == null) return false;
+
+    final doc = await _firestore
+        .collection('appUser')
+        .doc(uid)
+        .collection('scrapped_places')
+        .doc(placeId)
+        .get();
+
+    return doc.exists;
+  }
+  /// 현재 로그인한 사용자가 스크랩한 모든 장소 목록을 반환
+  Future<List<HomePlace>> fetchScrappedPlaces() async {
+  final uid = FirebaseAuth.instance.currentUser?.uid;
+  if (uid == null) return [];
+
+  final snapshot = await FirebaseFirestore.instance
+      .collection('appUser')
+      .doc(uid)
+      .collection('scrapped_places')
+      .get();
+
+  return snapshot.docs
+      .map((doc) => HomePlace.fromMap(doc.data()))
+      .toList();
+}
+
+}

--- a/lib/viewmodels/home/scrap_view_model.dart
+++ b/lib/viewmodels/home/scrap_view_model.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travel_muse_app/models/home/home_place.dart';
+import 'package:travel_muse_app/repositories/home/scrap_repository.dart';
+
+class ScrapViewModel extends StateNotifier<Set<String>> {
+  ScrapViewModel(this._repo) : super({});
+
+  final ScrapRepository _repo;
+
+  /// 특정 장소에 대해 스크랩 상태를 토글
+  /// 이미 스크랩되어 있으면 삭제하고 그렇지 않으면 스크랩한다
+  Future<void> toggleScrap(HomePlace place) async {
+    final isScrapped = state.contains(place.id);
+
+    if (isScrapped) {
+      await _repo.deleteScrap(place.id);
+      state = {...state}..remove(place.id);
+    } else {
+      await _repo.saveScrap(place);
+      state = {...state}..add(place.id);
+    }
+  }
+
+  /// 해당 장소 ID가 스크랩 상태인지 확인
+  bool isScrapped(String placeId) => state.contains(placeId);
+}

--- a/lib/viewmodels/user/scrap_list_view_model.dart
+++ b/lib/viewmodels/user/scrap_list_view_model.dart
@@ -1,0 +1,37 @@
+// scrap_list_view_model.dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travel_muse_app/models/home/home_place.dart';
+import 'package:travel_muse_app/repositories/home/scrap_repository.dart';
+
+class ScrapListViewModel extends StateNotifier<AsyncValue<List<HomePlace>>> {
+  ScrapListViewModel(this._repo) : super(const AsyncValue.loading()) {
+    load();
+  }
+
+  final ScrapRepository _repo;
+
+/// 북마크 리스트 불러오기
+  Future<void> load() async {
+    try {
+      final data = await _repo.fetchScrappedPlaces();
+      state = AsyncValue.data(data);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+///북마크 삭제 리스트에서도 삭제
+  Future<void> remove(HomePlace place) async {
+  try {
+    await _repo.deleteScrap(place.id); 
+
+    final current = state.asData?.value ?? [];
+    final updated = current.where((p) => p.id != place.id).toList();
+
+    state = AsyncValue.data(updated);
+  } catch (e, st) {
+    state = AsyncValue.error(e, st);
+  }
+}
+
+}

--- a/lib/views/home/recommended_place/recommended_place_detail_page.dart
+++ b/lib/views/home/recommended_place/recommended_place_detail_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/models/home/home_place.dart';
+import 'package:travel_muse_app/providers/home/scrap_provider.dart';
 import 'package:travel_muse_app/views/home/recommended_place/widgets/action_button_row.dart';
 import 'package:travel_muse_app/views/home/recommended_place/widgets/image_slider.dart';
 import 'package:travel_muse_app/views/home/recommended_place/widgets/location_row.dart';
@@ -9,23 +11,24 @@ import 'package:travel_muse_app/views/home/recommended_place/widgets/place_info_
 import 'package:travel_muse_app/views/home/recommended_place/widgets/place_map_view.dart';
 import 'package:travel_muse_app/views/home/recommended_place/widgets/place_stats_row.dart';
 
-class RecommendedPlaceDetailPage extends StatefulWidget {
+class RecommendedPlaceDetailPage extends ConsumerStatefulWidget {
   const RecommendedPlaceDetailPage({super.key, required this.place});
   final HomePlace place;
 
   @override
-  State<RecommendedPlaceDetailPage> createState() =>
+  ConsumerState<RecommendedPlaceDetailPage> createState() =>
       _RecommendedPlaceDetailPageState();
 }
 
 class _RecommendedPlaceDetailPageState
-    extends State<RecommendedPlaceDetailPage> {
+    extends ConsumerState<RecommendedPlaceDetailPage> {
   int _currentPage = 0;
   final PageController _pageController = PageController();
 
   @override
   Widget build(BuildContext context) {
     final place = widget.place;
+    final isScrapped = ref.watch(scrapViewModelProvider).contains(place.id);
 
     return Scaffold(
       backgroundColor: AppColors.white,
@@ -42,13 +45,12 @@ class _RecommendedPlaceDetailPageState
                 color: AppColors.grey[500],
                 size: 24,
               ),
-              onPressed:
-                  () => Navigator.pop(context, {
-                    'title': place.title,
-                    'lat': place.latLng.latitude,
-                    'lng': place.latLng.longitude,
-                    'address': place.address,
-                  }),
+              onPressed: () => Navigator.pop(context, {
+                'title': place.title,
+                'lat': place.latLng.latitude,
+                'lng': place.latLng.longitude,
+                'address': place.address,
+              }),
             ),
             const SizedBox(width: 4),
             Text(
@@ -60,10 +62,19 @@ class _RecommendedPlaceDetailPageState
                 fontFamily: 'Pretendard',
               ),
             ),
+            Spacer(),
+            IconButton(
+              icon: Icon(
+                isScrapped ? Icons.bookmark : Icons.bookmark_border,
+                color: isScrapped ? Colors.blue : Colors.grey,
+              ),
+              onPressed: () {
+                ref.read(scrapViewModelProvider.notifier).toggleScrap(place);
+              },
+            ),
           ],
         ),
       ),
-
       floatingActionButton: FloatingActionButton.extended(
         backgroundColor: AppColors.primary[50],
         foregroundColor: AppColors.primary[300],
@@ -90,21 +101,21 @@ class _RecommendedPlaceDetailPageState
               imageUrls: [place.thumbnail],
               currentPage: _currentPage,
               pageController: _pageController,
-              onPageChanged: (index) => setState(() => _currentPage = index),
+              onPageChanged: (index) =>
+                  setState(() => _currentPage = index),
             ),
             const SizedBox(height: 16),
             PlaceStatsRow(),
             const SizedBox(height: 12),
-            LocationRow(place: widget.place),
+            LocationRow(place: place),
             const SizedBox(height: 24),
             const ActionButtonRow(),
             const SizedBox(height: 24),
             PlaceDescription(),
             const SizedBox(height: 24),
-            PlaceMapView(place: widget.place),
+            PlaceMapView(place: place),
             const SizedBox(height: 16),
-            PlaceInfoSection(place: widget.place),
-            // const PlaceDirectionInfo(), 추후 추가 고려
+            PlaceInfoSection(place: place),
             const SizedBox(height: 80),
           ],
         ),

--- a/lib/views/my_page/my_scrap_list_page.dart
+++ b/lib/views/my_page/my_scrap_list_page.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travel_muse_app/providers/home/scrap_provider.dart';
+
+class MyScrapListPage extends ConsumerWidget {
+  const MyScrapListPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(scrapListViewModelProvider.notifier).load();
+    final state = ref.watch(scrapListViewModelProvider);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('북마크'),
+        centerTitle: false,
+        elevation: 0,
+      ),
+      body: state.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (err, _) => Center(child: Text('에러 발생: $err')),
+        data:
+            (places) => ListView.separated(
+              itemCount: places.length,
+              separatorBuilder:
+                  (_, __) => const Divider(height: 1, thickness: 0.5),
+              itemBuilder: (context, index) {
+                final place = places[index];
+                return Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 16,
+                    vertical: 12,
+                  ),
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      ClipRRect(
+                        borderRadius: BorderRadius.circular(8),
+                        child: Image.network(
+                          place.thumbnail,
+                          width: 64,
+                          height: 64,
+                          fit: BoxFit.cover,
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              place.title,
+                              style: const TextStyle(
+                                fontSize: 16,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              place.address,
+                              style: const TextStyle(
+                                fontSize: 14,
+                                color: Colors.grey,
+                              ),
+                            ),
+                            const SizedBox(height: 2),
+                            Text(
+                              '${place.category}',
+                              style: const TextStyle(
+                                fontSize: 13,
+                                color: Colors.grey,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.bookmark, color: Colors.blue),
+                        onPressed: () {
+                          ref
+                              .read(scrapListViewModelProvider.notifier)
+                              .remove(place);
+
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('스크랩이 해제되었어요'),
+                              duration: Duration(seconds: 2),
+                            ),
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                );
+              },
+            ),
+      ),
+    );
+  }
+}

--- a/lib/views/my_page/widgets/my_page_menu.dart
+++ b/lib/views/my_page/widgets/my_page_menu.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/views/my_page/my_scrap_list_page.dart';
 import 'package:travel_muse_app/views/my_page/plan_list_page.dart';
 import 'package:travel_muse_app/views/my_page/preference_list_page.dart';
 import 'package:travel_muse_app/views/my_page/settings/setting_page.dart';
@@ -15,7 +16,7 @@ class MyPageMenu extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          _buildMenuTitle('여행 일정'),
+          _buildMenuTitle('내 활동'),
 
           _buildMenuItem(
             title: '나의 여행',
@@ -23,6 +24,16 @@ class MyPageMenu extends StatelessWidget {
               Navigator.push(
                 context,
                 MaterialPageRoute(builder: (context) => PlanListPage()),
+              );
+            },
+          ),
+
+           _buildMenuItem(
+            title: '북마크',
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => MyScrapListPage()),
               );
             },
           ),


### PR DESCRIPTION
### 🚀: 개요
- 장소 스크랩(북마크) 
- 마이페이지에서 스크랩한 장소 목록을 확인할 수 있는 기능을 추가

### 🚀: 작업 내용
- HomePlace 모델에 toMap메서드 추가
- Firestore 연동을 위한 ScrapRepository 구현
- 스크랩 상태를 관리하는 ScrapViewModel 및 리스트 상태를 관리하는 ScrapListViewModel 작성
- 상세 페이지RecommendedPlaceDetailPage에서 스크랩 버튼 추가 및 동작 구현
- 마이페이지에 MyScrapListPage 생성하여 스크랩한 장소 목록 표시
- scrapProvider 설정으로 ViewModel 주입 관리
- my_page_menu에서 북마크 페이지로 이동 가능하도록 메뉴 구성

### 📸: 실행 화면
![Simulator Screenshot - iPhone 15 Pro Max - 2025-06-25 at 21 23 50](https://github.com/user-attachments/assets/aee7f8cf-d501-46fa-968f-3f5ad633a800)
![Simulator Screenshot - iPhone 15 Pro Max - 2025-06-25 at 21 23 42](https://github.com/user-attachments/assets/2748a887-fb9c-4514-8c54-e4541c45c4d1)


### 🚀: 조정 파일
- my_page_menu.dart
- my_scrap_list_page.dart
- recommended_place_detail_page.dart
- scrap_list_view_model.dart
- scrap_view_model.dart
- scrap_repository.dart
- scrap_provider.dart
- home_place.dart

### 개발 결과
- 스크랩 버튼을 눌러 장소를 저장하거나 해제할 수 있음
- 마이페이지 내 북마크 메뉴에서 스크랩한 장소 목록을 확인 가능
- Firestore와 연동하여 데이터가 실시간으로 반영됨
- 스크랩 해제 시 리스트에서 즉시 제거되고, 스낵바로 알림 표시됨

### issue
Closes #213 
