### PR TITLE
[Etc] 바텀 네비게이션 바 오류 픽스

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,6 +11,8 @@ import 'package:travel_muse_app/firebase_options.dart';
 import 'package:travel_muse_app/utills/notification_helper.dart';
 import 'package:travel_muse_app/views/user/splash/splash_page.dart';
 
+final RouteObserver<ModalRoute<void>> routeObserver = RouteObserver<ModalRoute<void>>();
+
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
@@ -35,6 +37,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
+      navigatorObservers: [routeObserver],
       builder: EasyLoading.init(),
       theme: ThemeData(
         scaffoldBackgroundColor: Colors.white,

--- a/lib/views/home/home_page.dart
+++ b/lib/views/home/home_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/bottom_bar_provider.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
+import 'package:travel_muse_app/main.dart';
 import 'package:travel_muse_app/providers/user/app_user_view_model_provider.dart';
 import 'package:travel_muse_app/views/home/widgets/info_banner.dart';
 import 'package:travel_muse_app/views/home/widgets/recommended_places_list.dart';
@@ -9,11 +11,33 @@ import 'package:travel_muse_app/views/home/widgets/recommended_restaurants_list.
 import 'package:travel_muse_app/views/home/widgets/section_title.dart';
 import 'package:travel_muse_app/views/home/widgets/travel_register_button.dart';
 
-class HomePage extends ConsumerWidget {
+class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ConsumerStatefulWidget> createState() => _HomePageState();
+}
+
+class _HomePageState extends ConsumerState<HomePage> with RouteAware {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    routeObserver.subscribe(this, ModalRoute.of(context)!);
+  }
+
+  @override
+  void dispose() {
+    routeObserver.unsubscribe(this);
+    super.dispose();
+  }
+
+  @override
+  void didPopNext() {
+    ref.read(bottomBarProvider.notifier).state = 0;
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final appUserAsync = ref.watch(appUserViewModelProvider);
 
     return Scaffold(

--- a/lib/views/post/post_list_page.dart
+++ b/lib/views/post/post_list_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_text_styles.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/views/post/widgets/list/post_list_view.dart';
 import 'package:travel_muse_app/views/post/widgets/list/tag_bar.dart';
 import 'package:travel_muse_app/views/post/widgets/write/write_fab.dart';
@@ -17,6 +18,7 @@ class PostListPage extends StatelessWidget {
       ),
       body: Column(children: [TagBar(), PostListView()]),
       floatingActionButton: const WriteFab(),
+      bottomNavigationBar: const BottomBar(),
     );
   }
 }


### PR DESCRIPTION
### 🚀: 개요
- 바텀 네비게이션 바 오류 픽스

### 🚀: 작업 내용
- RouteObserver 홈페이지 관리로 바텀네비게이션바 오류 픽스
- PostListPage(커뮤니티 탭) 에서 바텀네비게이션바 활성화

### 📸: 실행 화면
<img src="https://github.com/user-attachments/assets/0f4a32aa-6e27-48b5-a473-94889c969039" width="300" height="640"/>

### 🚀: 조정 파일
- lib/main.dart
- lib/views/home/home_page.dart
- lib/views/post/post_list_page.dart

### 개발 결과
- 바텀 네비게이션바 오류 픽스 
- PostListPage에서 바텀네비게이션바 활성화

### issue
Closes #221
