### PR TITLE
[Plan] 캘린더 당일 여행 선택 기능 구현

### DIFF
--- a/lib/repositories/plan/calendar_location_repository.dart
+++ b/lib/repositories/plan/calendar_location_repository.dart
@@ -11,15 +11,16 @@ class CalendarLocationRepository {
   Future<void> savePlan({
     required String planId,
     required DateTime startDate,
-    required DateTime endDate,
+    required DateTime? endDate, // 수정: nullable 허용
     required String region,
     required String userId,
   }) async {
-    final duration = endDate.difference(startDate).inDays + 1;
+    final actualEndDate = endDate ?? startDate; // 하루짜리 처리
+    final duration = actualEndDate.difference(startDate).inDays + 1;
 
     await _firestore.collection('plans').doc(planId).set({
       'startDate': Timestamp.fromDate(startDate),
-      'endDate': Timestamp.fromDate(endDate),
+      'endDate': Timestamp.fromDate(actualEndDate),
       'duration': duration,
       'region': region,
       'userId': userId,
@@ -29,18 +30,19 @@ class CalendarLocationRepository {
   /// 새 planId를 생성하고 플랜 데이터를 Firestore에 저장
   Future<String> createAndSavePlan({
     required DateTime startDate,
-    required DateTime endDate,
+    required DateTime? endDate, // 수정: nullable 허용
     required String region,
     required String userId,
   }) async {
-    final duration = endDate.difference(startDate).inDays + 1;
+    final actualEndDate = endDate ?? startDate; // 하루짜리 처리
+    final duration = actualEndDate.difference(startDate).inDays + 1;
 
     final docRef = _firestore.collection('plans').doc();
     final planId = docRef.id;
 
     await docRef.set({
       'startDate': Timestamp.fromDate(startDate),
-      'endDate': Timestamp.fromDate(endDate),
+      'endDate': Timestamp.fromDate(actualEndDate),
       'duration': duration,
       'region': region,
       'userId': userId,

--- a/lib/utills/date_utils.dart
+++ b/lib/utills/date_utils.dart
@@ -31,14 +31,21 @@ int getTripDays(DateTime start, DateTime end) {
 
 // 버튼에 보여줄 텍스트 생성 함수
 String getButtonText(DateTime? startDay, DateTime? endDay) {
-  if (startDay == null || endDay == null) {
+  if (startDay == null) {
     return '다음';
+  }
+
+  final actualEndDay = endDay ?? startDay;
+
+  final startStr =
+      '${startDay.year}.${startDay.month.toString().padLeft(2, '0')}.${startDay.day.toString().padLeft(2, '0')}';
+  final endStr =
+      '${actualEndDay.year}.${actualEndDay.month.toString().padLeft(2, '0')}.${actualEndDay.day.toString().padLeft(2, '0')}';
+  final days = getTripDays(startDay, actualEndDay);
+
+  if (startDay == actualEndDay) {
+    return '$startStr ($days일) 선택하기'; // 당일 여행이면 ~ 없이 단일 날짜만 출력
   } else {
-    final startStr =
-        '${startDay.year}.${startDay.month.toString().padLeft(2, '0')}.${startDay.day.toString().padLeft(2, '0')}';
-    final endStr =
-        '${endDay.year}.${endDay.month.toString().padLeft(2, '0')}.${endDay.day.toString().padLeft(2, '0')}';
-    final days = getTripDays(startDay, endDay);
     return '$startStr ~ $endStr ($days일) 선택하기';
   }
 }

--- a/lib/utills/date_utils.dart
+++ b/lib/utills/date_utils.dart
@@ -44,7 +44,7 @@ String getButtonText(DateTime? startDay, DateTime? endDay) {
   final days = getTripDays(startDay, actualEndDay);
 
   if (startDay == actualEndDay) {
-    return '$startStr ($days일) 선택하기'; // 당일 여행이면 ~ 없이 단일 날짜만 출력
+    return '$startStr ($days일) 선택하기';
   } else {
     return '$startStr ~ $endStr ($days일) 선택하기';
   }

--- a/lib/viewmodels/plan/calendar_location_view_model.dart
+++ b/lib/viewmodels/plan/calendar_location_view_model.dart
@@ -8,22 +8,18 @@ class CalendarLocationViewModel extends StateNotifier<PlanState> {
 
   final Ref ref;
 
-  /// 시작 날짜를 설정
   void setStartDate(DateTime date) {
     state = state.copyWith(startDate: date);
   }
 
-  /// 종료 날짜를 설정
   void setEndDate(DateTime date) {
     state = state.copyWith(endDate: date);
   }
 
-  /// 여행 지역을 설정
   void setRegion(String region) {
     state = state.copyWith(region: region);
   }
 
-  /// 외부에서 planId가 주어진 경우, 해당 plan 데이터를 Firestore에 저장
   Future<void> savePlan(String planId) async {
     final start = state.startDate;
     final end = state.endDate;
@@ -46,7 +42,6 @@ class CalendarLocationViewModel extends StateNotifier<PlanState> {
     state = state.copyWith(planId: planId);
   }
 
-  /// 내부에서 planId를 생성하여 plan 데이터를 저장
   Future<String> createAndSavePlan() async {
     final start = state.startDate;
     final end = state.endDate;
@@ -70,12 +65,10 @@ class CalendarLocationViewModel extends StateNotifier<PlanState> {
     return planId;
   }
 
-  /// 시작일과 종료일을 함께 설정
   void setDateRange(DateTime start, DateTime end) {
     state = state.copyWith(startDate: start, endDate: end);
   }
 
-  /// 유저의 가장 가까운 미래의 플랜을 로드
   Future<void> loadNearestUpcomingPlan() async {
     final userId = ref.read(authViewModelProvider).user?.uid;
     if (userId == null) return;
@@ -85,6 +78,50 @@ class CalendarLocationViewModel extends StateNotifier<PlanState> {
 
     if (plan != null) {
       state = plan;
+    }
+  }
+
+  /// *** 새로 추가된 메서드 ***
+  /// 날짜와 지역을 인자로 받아 상태를 세팅하고 저장까지 처리하는 통합 함수
+  Future<String> savePlanWithDates(
+    String region,
+    DateTime startDate,
+    DateTime endDate,
+  ) async {
+    final userId = ref.read(authViewModelProvider).user?.uid;
+    if (userId == null) {
+      throw Exception('사용자 정보가 누락되었습니다.');
+    }
+
+    // 상태 업데이트
+    state = state.copyWith(
+      region: region,
+      startDate: startDate,
+      endDate: endDate,
+    );
+
+    final repo = ref.read(calendarLocationRepositoryProvider);
+
+    if (state.planId != null) {
+      // 기존 planId가 있으면 업데이트
+      await repo.savePlan(
+        planId: state.planId!,
+        startDate: startDate,
+        endDate: endDate,
+        region: region,
+        userId: userId,
+      );
+      return state.planId!;
+    } else {
+      // 새로 생성 및 저장
+      final newPlanId = await repo.createAndSavePlan(
+        startDate: startDate,
+        endDate: endDate,
+        region: region,
+        userId: userId,
+      );
+      state = state.copyWith(planId: newPlanId);
+      return newPlanId;
     }
   }
 }

--- a/lib/viewmodels/plan/calendar_location_view_model.dart
+++ b/lib/viewmodels/plan/calendar_location_view_model.dart
@@ -81,7 +81,6 @@ class CalendarLocationViewModel extends StateNotifier<PlanState> {
     }
   }
 
-  /// *** 새로 추가된 메서드 ***
   /// 날짜와 지역을 인자로 받아 상태를 세팅하고 저장까지 처리하는 통합 함수
   Future<String> savePlanWithDates(
     String region,

--- a/lib/viewmodels/plan/calendar_view_model.dart
+++ b/lib/viewmodels/plan/calendar_view_model.dart
@@ -34,6 +34,9 @@ class CalendarViewModel extends StateNotifier<CalendarState> {
           focusedDay: newFocusedDay,
         );
       }
+      print(
+        'selectDay called: startDay=${state.startDay}, endDay=${state.endDay}',
+      );
     }
   }
 
@@ -48,5 +51,15 @@ class CalendarViewModel extends StateNotifier<CalendarState> {
         state.endDay != null &&
         day.isAfter(state.startDay!) &&
         day.isBefore(state.endDay!);
+  }
+
+  /// endDay가 null이면 startDay로 설정
+  void ensureEndDay() {
+    final start = state.startDay;
+    final end = state.endDay;
+
+    if (start != null && end == null) {
+      state = state.copyWith(endDay: start);
+    }
   }
 }

--- a/lib/viewmodels/plan/calendar_view_model.dart
+++ b/lib/viewmodels/plan/calendar_view_model.dart
@@ -34,9 +34,6 @@ class CalendarViewModel extends StateNotifier<CalendarState> {
           focusedDay: newFocusedDay,
         );
       }
-      print(
-        'selectDay called: startDay=${state.startDay}, endDay=${state.endDay}',
-      );
     }
   }
 

--- a/lib/views/plan/plan/calendar/calendar_page.dart
+++ b/lib/views/plan/plan/calendar/calendar_page.dart
@@ -68,8 +68,17 @@ class CalendarPage extends ConsumerWidget {
                     ),
                   ),
                   onPressed: () {
-                    if (state.startDay != null && state.endDay != null) {
-                      // 날짜가 모두 선택된 경우 다음 화면으로 이동
+                    final viewModel = ref.read(
+                      calendarViewModelProvider.notifier,
+                    );
+                    final state = ref.read(calendarViewModelProvider);
+
+                    final start = state.startDay;
+                    final end = state.endDay;
+
+                    if (start != null) {
+                      viewModel.ensureEndDay();
+
                       Navigator.push(
                         context,
                         MaterialPageRoute(
@@ -77,12 +86,12 @@ class CalendarPage extends ConsumerWidget {
                         ),
                       );
                     } else {
-                      // 날짜가 선택되지 않은 경우 안내 메시지 띄우기
                       ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('여행 날짜를 모두 선택해주세요.')),
+                        const SnackBar(content: Text('여행 날짜를 선택해주세요.')),
                       );
                     }
                   },
+
                   child: Text(
                     getButtonText(state.startDay, state.endDay),
                     style: const TextStyle(fontSize: 16, color: Colors.white),

--- a/lib/views/plan/plan/location_setting/widgets/save_button.dart
+++ b/lib/views/plan/plan/location_setting/widgets/save_button.dart
@@ -47,18 +47,22 @@ class SaveButton extends ConsumerWidget {
   Future<void> _handleSave(BuildContext context, WidgetRef ref) async {
     final selectedDistrict = districts[selectedIndex!];
 
-    final calendarState = ref.read(calendarViewModelProvider);
+    final calendarState = ref.watch(calendarViewModelProvider);
+    print(
+      'SaveButton _handleSave: startDay=${calendarState.startDay}, endDay=${calendarState.endDay}',
+    );
     final locationViewModel = ref.read(
       calendarLocationViewModelProvider.notifier,
     );
 
     locationViewModel.setRegion('$selectedProvince $selectedDistrict');
 
-    if (calendarState.startDay != null && calendarState.endDay != null) {
-      locationViewModel.setDateRange(
-        calendarState.startDay!,
-        calendarState.endDay!,
-      );
+    // startDay가 null이면 endDay 값으로 대체, 둘 다 null이면 저장 불가
+    final startDay = calendarState.startDay ?? calendarState.endDay;
+    final endDay = calendarState.endDay ?? calendarState.startDay;
+
+    if (startDay != null && endDay != null) {
+      locationViewModel.setDateRange(startDay, endDay);
     } else {
       ScaffoldMessenger.of(
         context,

--- a/lib/views/plan/plan/location_setting/widgets/save_button.dart
+++ b/lib/views/plan/plan/location_setting/widgets/save_button.dart
@@ -48,16 +48,13 @@ class SaveButton extends ConsumerWidget {
     final selectedDistrict = districts[selectedIndex!];
 
     final calendarState = ref.watch(calendarViewModelProvider);
-    print(
-      'SaveButton _handleSave: startDay=${calendarState.startDay}, endDay=${calendarState.endDay}',
-    );
+
     final locationViewModel = ref.read(
       calendarLocationViewModelProvider.notifier,
     );
 
     locationViewModel.setRegion('$selectedProvince $selectedDistrict');
 
-    // startDay가 null이면 endDay 값으로 대체, 둘 다 null이면 저장 불가
     final startDay = calendarState.startDay ?? calendarState.endDay;
     final endDay = calendarState.endDay ?? calendarState.startDay;
 


### PR DESCRIPTION
### 🚀: 개요
[Plan] 캘린더 당일 여행 선택 기능 구현

### 🚀: 작업 내용
- 당일 여행 선택 기능
- 당일 여행 저장 기능

### 📸: 실행 화면
### 📸: 실행 화면
<img width="308" alt="스크린샷 2025-06-26 오후 7 04 33" src="https://github.com/user-attachments/assets/0190d569-2b7e-47c9-82c8-1c589eceda26" />


### 🚀: 조정 파일
- save_button.dart
- calendar_location_view_model.dart
- calendar_location_repository.dart
- calendar_view_model.dart

### 개발 결과
- 당일 선택가능 뷰모델 조정
- 당일 선택 저장 로직 개선
- 선택 날짜 null 보완

### issue
Closes #217 
