### PR TITLE
[ETC] 신고된 콘텐츠 관리 관리코드 text 추가

### DIFF
--- a/lib/models/scoial/reported_comment.dart
+++ b/lib/models/scoial/reported_comment.dart
@@ -5,6 +5,8 @@ class ReportedComment {
   final String userId;
   final String? nickname;
   final String content;
+  final List<String> reasonCode;
+  final List<String?> reasonText;
   final DateTime createdAt;
   final bool isReposted;
   final int reportCount;
@@ -14,6 +16,8 @@ class ReportedComment {
     required this.commentId,
     required this.userId,
     required this.content,
+    required this.reasonCode,
+    required this.reasonText,
     required this.createdAt,
     required this.isReposted,
     required this.reportCount,
@@ -24,7 +28,9 @@ class ReportedComment {
   factory ReportedComment.fromJson(
     Map<String, dynamic> json,
     String postId,
-    String commentId, {
+    String commentId,
+    List<String> reasonCode,
+    List<String?> reasonText, {
     String? nickname,
   }) {
     return ReportedComment(
@@ -35,8 +41,9 @@ class ReportedComment {
       createdAt: (json['createdAt'] as Timestamp).toDate(),
       isReposted: json['isReposted'] ?? false,
       reportCount: json['reportCount'] ?? 0,
-      nickname: nickname
+      reasonCode: reasonCode,
+      reasonText: reasonText,
+      nickname: nickname,
     );
   }
 }
-

--- a/lib/models/scoial/reported_post.dart
+++ b/lib/models/scoial/reported_post.dart
@@ -5,6 +5,8 @@ class ReportedPost {
   final String userId;
   final String? nickname;
   final String content;
+  final List<String> reasonCode;
+  final List<String?> reasonText;
   final List<String> images;
   final DateTime createdAt;
   final bool isDeleted;
@@ -15,20 +17,30 @@ class ReportedPost {
     required this.postId,
     required this.userId,
     required this.content,
+    required this.reasonCode,
+    required this.reasonText,
     required this.images,
     required this.createdAt,
     required this.isDeleted,
     required this.isReposted,
     required this.reportCount,
-    this.nickname
+    this.nickname,
   });
 
-  factory ReportedPost.fromJson(Map<String, dynamic> json, String postId, {String? nickname}) {
+  factory ReportedPost.fromJson(
+    Map<String, dynamic> json,
+    String postId, {
+    required List<String> reasonCode,
+    required List<String?> reasonText,
+    String? nickname,
+  }) {
     return ReportedPost(
       postId: postId,
       userId: json['userId'] ?? '',
       nickname: nickname,
       content: json['content'] ?? '',
+      reasonCode: reasonCode,
+      reasonText: reasonText,
       images: List<String>.from(json['images'] ?? []),
       createdAt: (json['createAt'] as Timestamp).toDate(),
       isDeleted: json['isDeleted'] ?? false,

--- a/lib/repositories/scoial/admin_report_repository.dart
+++ b/lib/repositories/scoial/admin_report_repository.dart
@@ -30,7 +30,26 @@ class AdminReportRepository {
                 ? (userSnapshot.data()?['nickname'] ?? '알 수 없음')
                 : '탈퇴한 사용자';
 
-        return ReportedPost.fromJson(data, postId, nickname: nickname);
+        // 신고 문서 조회
+        final reports =
+            await _firestore
+                .collection('reports')
+                .where('targetType', isEqualTo: 'post')
+                .where('targetId', isEqualTo: postId)
+                .get();
+
+        final reasonCode =
+            reports.docs.map((e) => e.data()['reasonCode'] as String).toList();
+        final reasonText =
+            reports.docs.map((e) => e.data()['reasonText'] as String?).toList();
+
+        return ReportedPost.fromJson(
+          data,
+          postId,
+          reasonCode: reasonCode,
+          reasonText: reasonText,
+          nickname: nickname,
+        );
       }),
     );
   }
@@ -50,6 +69,24 @@ class AdminReportRepository {
         final commentId = doc.id;
         final userId = data['userId'];
 
+        // 각 댓글에 대한 신고 사유 가져오기
+        final reportQuery =
+            await _firestore
+                .collection('reports')
+                .where('targetType', isEqualTo: 'comment')
+                .where('targetId', isEqualTo: commentId)
+                .get();
+
+        final reasonCode =
+            reportQuery.docs
+                .map((e) => e.data()['reasonCode'] as String)
+                .toList();
+
+        final reasonText =
+            reportQuery.docs
+                .map((e) => e.data()['reasonText'] as String?)
+                .toList();
+
         final userSnapshot =
             await _firestore.collection('appUser').doc(userId).get();
         final nickname =
@@ -61,6 +98,8 @@ class AdminReportRepository {
           data,
           postId,
           commentId,
+          reasonCode,
+          reasonText,
           nickname: nickname,
         );
       }),

--- a/lib/views/post/post_detail_page.dart
+++ b/lib/views/post/post_detail_page.dart
@@ -2,7 +2,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
-import 'package:http/http.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/models/post/post_model.dart';
@@ -20,8 +19,16 @@ import 'package:travel_muse_app/views/post/widgets/detail/post_detail_tags_and_m
 import 'package:travel_muse_app/views/post/widgets/detail/show_report_reason_dialog.dart';
 
 class PostDetailPage extends ConsumerStatefulWidget {
-  const PostDetailPage({super.key, required this.post});
-  final Post post;
+  const PostDetailPage({
+    super.key,
+    this.post,
+    this.postId,
+    this.scrollToCommentId,
+  });
+
+  final Post? post;
+  final String? postId;
+  final String? scrollToCommentId;
 
   @override
   ConsumerState<PostDetailPage> createState() => _PostDetailPageState();
@@ -35,10 +42,25 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
   @override
   void initState() {
     super.initState();
-    currentPost = widget.post;
+    currentPost = widget.post!;
 
     Future.microtask(() async {
       final postRepo = ref.read(postRepositoryProvider);
+
+      if (widget.post != null) {
+        currentPost = widget.post!;
+      } else if (widget.postId != null) {
+        final fetched = await postRepo.fetchPostById(widget.postId!);
+        if (fetched != null) {
+          currentPost = fetched;
+        } else {
+          if (mounted) Navigator.pop(context);
+          return;
+        }
+      } else {
+        if (mounted) Navigator.pop(context);
+        return;
+      }
 
       // 조회수 증가
       await postRepo.incrementViewCount(currentPost.postId);
@@ -243,7 +265,7 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
                 likeViewModelProvider(
                   LikeViewModelParams(
                     postId: currentPost.postId,
-                    userId: user!.uid,
+                    userId: user.uid,
                   ),
                 ),
               ),

--- a/lib/views/user/admin/admin_report_screen.dart
+++ b/lib/views/user/admin/admin_report_screen.dart
@@ -6,6 +6,7 @@ import 'package:travel_muse_app/providers/post/post_provider.dart';
 import 'package:travel_muse_app/providers/scoial/admin_report_provider.dart';
 import 'package:travel_muse_app/views/post/post_detail_page.dart';
 import 'package:travel_muse_app/views/user/admin/widgets/reported_card.dart';
+import 'package:travel_muse_app/views/user/admin/widgets/show_reason_dialog.dart';
 
 class AdminReportScreen extends ConsumerStatefulWidget {
   const AdminReportScreen({super.key});
@@ -31,63 +32,93 @@ class _AdminReportScreenState extends ConsumerState<AdminReportScreen> {
     return Scaffold(
       appBar: AppBar(title: const Text('신고된 콘텐츠 관리')),
       body: state.when(
-        data: (items) => RefreshIndicator(
-          onRefresh: () => viewModel.fetchReports(),
-          child: ListView.builder(
-            itemCount: items.length,
-            itemBuilder: (context, index) {
-              final item = items[index];
+        data:
+            (items) => RefreshIndicator(
+              onRefresh: () => viewModel.fetchReports(),
+              child: ListView.builder(
+                itemCount: items.length,
+                itemBuilder: (context, index) {
+                  final item = items[index];
 
-              if (item is ReportedPost) {
-                return ReportedCard(
-                  title: '[게시글] ${item.content}',
-                  subtitle: '작성자: ${item.nickname}\n신고 수: ${item.reportCount}',
-                  onTap: () async {
-                    final postRepo = ref.read(postRepositoryProvider);
-                    final post = await postRepo.fetchPostById(item.postId);
+                  if (item is ReportedPost) {
+                    return ReportedCard(
+                      title: '[게시글] ${item.content}',
+                      subtitle:
+                          '작성자: ${item.nickname}\n신고 수: ${item.reportCount}',
+                      onTap: () async {
+                        final postRepo = ref.read(postRepositoryProvider);
+                        final post = await postRepo.fetchPostById(item.postId);
 
-                    if (post != null && context.mounted) {
-                      await Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => PostDetailPage(post: post),
-                        ),
-                      );
-                    } else {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('게시글을 불러올 수 없습니다.')),
-                      );
-                    }
-                  },
-                  onDelete: () => viewModel.deletePost(item.postId),
-                  onClear: () => viewModel.clearReport('post', item.postId),
-                );
-              } else if (item is ReportedComment) {
-                return ReportedCard(
-                  title: '[댓글] ${item.content}',
-                  subtitle:
-                      '작성자: ${item.nickname} \n신고 수: ${item.reportCount}',
-                  onTap: () {
-                    // 댓글 탭으로 이동 등 구현 가능
-                  },
-                  onDelete: () =>
-                      viewModel.deleteComment(item.postId, item.commentId),
-                  onClear: () => viewModel.clearReport(
-                    'comment',
-                    item.commentId,
-                    postId: item.postId,
-                  ),
-                );
-              } else {
-                return const SizedBox.shrink();
-              }
-            },
-          ),
-        ),
+                        if (post != null && context.mounted) {
+                          await Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => PostDetailPage(post: post),
+                            ),
+                          );
+                        } else {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('게시글을 불러올 수 없습니다.')),
+                          );
+                        }
+                      },
+
+                      onDelete: () => viewModel.deletePost(item.postId),
+                      onClear: () => viewModel.clearReport('post', item.postId),
+                      onShowReasons: () {
+                        showReasonDialog(
+                          context,
+                          item.reasonCode,
+                          item.reasonText,
+                        );
+                      },
+                    );
+                  } else if (item is ReportedComment) {
+                    return ReportedCard(
+                      title: '[댓글] ${item.content}',
+                      subtitle:
+                          '작성자: ${item.nickname}\n신고 수: ${item.reportCount}',
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder:
+                                (_) => PostDetailPage(
+                                  postId: item.postId,
+                                  scrollToCommentId: item.commentId,
+                                ),
+                          ),
+                        );
+                      },
+
+                      onDelete:
+                          () => viewModel.deleteComment(
+                            item.postId,
+                            item.commentId,
+                          ),
+                      onClear:
+                          () => viewModel.clearReport(
+                            'comment',
+                            item.commentId,
+                            postId: item.postId,
+                          ),
+                      onShowReasons: () {
+                        showReasonDialog(
+                          context,
+                          item.reasonCode,
+                          item.reasonText,
+                        );
+                      },
+                    );
+                  } else {
+                    return const SizedBox.shrink();
+                  }
+                },
+              ),
+            ),
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => Center(child: Text('에러: $e')),
       ),
     );
   }
 }
-

--- a/lib/views/user/admin/widgets/reported_card.dart
+++ b/lib/views/user/admin/widgets/reported_card.dart
@@ -5,36 +5,37 @@ class ReportedCard extends StatelessWidget {
     super.key,
     required this.title,
     required this.subtitle,
-    this.onDelete,
+    required this.onTap,
+    required this.onDelete,
     required this.onClear,
-    this.onTap,
+    this.onShowReasons,
   });
-
   final String title;
   final String subtitle;
-  final VoidCallback? onDelete;
+  final VoidCallback onTap;
+  final VoidCallback onDelete;
   final VoidCallback onClear;
-  final VoidCallback? onTap;
+  final VoidCallback? onShowReasons; 
+
 
   @override
   Widget build(BuildContext context) {
     return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: ListTile(
+        title: Text(title),
+        subtitle: Text(subtitle),
         onTap: onTap,
-        title: Text(title, overflow: TextOverflow.ellipsis, softWrap: true),
-        subtitle: Text(subtitle, softWrap: true),
-        trailing: SizedBox(
-          width: 96,
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (onDelete != null)
-                IconButton(icon: const Icon(Icons.delete), onPressed: onDelete),
-              IconButton(icon: const Icon(Icons.clear), onPressed: onClear),
-            ],
-          ),
+        trailing: PopupMenuButton<String>(
+          onSelected: (value) {
+            if (value == 'delete') onDelete();
+            else if (value == 'clear') onClear();
+            else if (value == 'reasons' && onShowReasons != null) onShowReasons!();
+          },
+          itemBuilder: (_) => [
+            const PopupMenuItem(value: 'delete', child: Text('삭제')),
+            const PopupMenuItem(value: 'clear', child: Text('신고 해제')),
+            const PopupMenuItem(value: 'reasons', child: Text('신고 사유 보기')),
+          ],
         ),
       ),
     );

--- a/lib/views/user/admin/widgets/show_reason_dialog.dart
+++ b/lib/views/user/admin/widgets/show_reason_dialog.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+void showReasonDialog(
+  BuildContext context,
+  List<String> reasonCodes,
+  List<String?> reasonTexts,
+) {
+  showDialog(
+    context: context,
+    builder: (_) => AlertDialog(
+      title: const Text('신고 사유'),
+      content: SizedBox(
+        width: double.maxFinite,
+        child: ListView.builder(
+          shrinkWrap: true,
+          itemCount: reasonCodes.length,
+          itemBuilder: (_, index) {
+            final code = reasonCodes[index];
+            final text = reasonTexts[index] ?? '';
+            return ListTile(
+              title: Text(code),
+              subtitle: text.isNotEmpty ? Text(text) : null,
+            );
+          },
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(context),
+          child: const Text('닫기'),
+        ),
+      ],
+    ),
+  );
+}


### PR DESCRIPTION
### 🚀: 개요
- 신고된 게시글 및 댓글의 신고 사유(reasonCode, reasonText) 확인 기능 추가

### 🚀: 작업 내용
- AdminReportRepository 게시글/댓글 신고 사유 필드 조회 로직 추가
- ReportedPost, ReportedComment 모델신고 사유 필드 추가
- AdminReportScreen 신고사유 확인 버튼 추가
- ReportedCard, show_reason_dialog 팝업 UI 구현

### 📸: 실행 화면
![Simulator Screenshot - iPhone 15 Pro Max - 2025-06-27 at 11 02 22](https://github.com/user-attachments/assets/32e06b04-39f7-438b-97db-dcebd2ebb5b9)


### 🚀: 조정 파일
- admin_report_repository.dart
- reported_post.dart
- reported_comment.dart
- admin_report_screen.dart
- reported_card.dart
- show_reason_dialog.dart
- post_detail_page.dart

### 개발 결과
- 관리자 화면에서 신고된 콘텐츠 클릭 시 신고 사유 확인 가능
- 신고사유가 누락되지 않고 정확히 표기됨
- 기존 기능은 그대로 유지됨 (게시글 상세보기, 삭제, 클리어 등)

### issue
Closes #235 
