### PR TITLE
[MyPage] 계정 관리 페이지 피그마 적용

### DIFF
--- a/lib/views/my_page/settings/account_setting_page.dart
+++ b/lib/views/my_page/settings/account_setting_page.dart
@@ -1,13 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
+import 'package:travel_muse_app/providers/user/auth_view_model_provider.dart';
 import 'package:travel_muse_app/views/my_page/widgets/account_info.dart';
-import 'package:travel_muse_app/views/my_page/widgets/delete_account_button.dart';
-import 'package:travel_muse_app/views/my_page/widgets/log_out_button.dart';
+import 'package:travel_muse_app/views/my_page/widgets/confirm_dialog.dart';
 import 'package:travel_muse_app/views/my_page/widgets/my_profile_screen.dart';
-import 'package:travel_muse_app/views/my_page/widgets/user_info.dart';
+import 'package:travel_muse_app/views/user/login/login_page.dart';
 
-class AccountSettingPage extends StatelessWidget {
+class AccountSettingPage extends ConsumerStatefulWidget {
   const AccountSettingPage({super.key});
 
+  @override
+  ConsumerState<AccountSettingPage> createState() => _AccountSettingPageState();
+}
+
+class _AccountSettingPageState extends ConsumerState<AccountSettingPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -28,14 +36,90 @@ class AccountSettingPage extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Center(child: MyProfileScreen()),
-          Divider(),
+          Container(
+            width: double.infinity,
+            height: 5,
+            decoration: BoxDecoration(color: AppColors.grey[50]),
+          ),
           AccountInfo(),
-          Divider(),
-          UserInfo(),
-          LogOutButton(),
-          DeleteAccountButton(),
+          Spacer(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              GestureDetector(
+                onTap: () {
+                  _logOut(context, ref);
+                },
+                child: bottomTextButton('로그아웃'),
+              ),
+              SizedBox(
+                height: 14,
+                child: VerticalDivider(
+                  width: 14,
+                  color: AppColors.grey[600],
+                  thickness: 0.5,
+                ),
+              ),
+              GestureDetector(
+                onTap: () {
+                  _showConfirmDialog(ref);
+                },
+                child: bottomTextButton('회원탈퇴'),
+              ),
+            ],
+          ),
         ],
       ),
+      bottomNavigationBar: const BottomBar(),
     );
+  }
+
+  Widget bottomTextButton(String text) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Text(
+        text,
+        style: TextStyle(
+          color: AppColors.grey[600],
+          fontSize: 12,
+          fontFamily: 'Pretendard',
+          fontWeight: FontWeight.w400,
+          height: 1.50,
+        ),
+      ),
+    );
+  }
+
+  void _logOut(BuildContext context, WidgetRef ref) {
+    ref.read(authViewModelProvider.notifier).logout();
+    Navigator.pushAndRemoveUntil(
+      context,
+      MaterialPageRoute(builder: (_) => LoginPage()),
+      (route) => false,
+    );
+  }
+
+  Future<void> _showConfirmDialog(WidgetRef ref) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder:
+          (context) => const ConfirmDialog(
+            title: '탈퇴하시겠습니까?',
+            description: '작성한 글, 댓글은 자동으로 삭제되지 않아요',
+          ),
+    );
+
+    if (!mounted) return;
+
+    if (result == true) {
+      await ref.read(authViewModelProvider.notifier).deleteAccount();
+
+      if (!mounted) return;
+
+      await Navigator.of(context).pushAndRemoveUntil(
+        MaterialPageRoute(builder: (_) => const LoginPage()),
+        (route) => false,
+      );
+    }
   }
 }

--- a/lib/views/my_page/widgets/account_info.dart
+++ b/lib/views/my_page/widgets/account_info.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/providers/user/app_user_view_model_provider.dart';
 
 class AccountInfo extends ConsumerStatefulWidget {
@@ -21,23 +22,98 @@ class _AccountInfoState extends ConsumerState<AccountInfo> {
   @override
   Widget build(BuildContext context) {
     final appUserAsync = ref.watch(appUserViewModelProvider);
-    return SizedBox(
-      child: appUserAsync.when(
-        data:
-            (data) => Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text(
-                  '계정 정보',
-                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.w700),
-                ),
-                Text(data.loginProvider ?? ''),
-                Text(data.loginEmail ?? ''),
-              ],
-            ),
-        loading: () => CircularProgressIndicator(),
-        error: (e, _) => Text('프로필 정보 불러오기 실패: $e'),
+    final screenWidth = MediaQuery.of(context).size.width;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(vertical: 16),
+        decoration: BoxDecoration(
+          border: Border(bottom: BorderSide(width: 1, color: AppColors.grey[50]!)),
+        ),
+        child: appUserAsync.when(
+          data:
+              (data) => Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '계정 정보',
+                    style: TextStyle(
+                      color: AppColors.black,
+                      fontSize: 18,
+                      fontFamily: 'Pretendard',
+                      fontWeight: FontWeight.w600,
+                      height: 1.50,
+                    ),
+                  ),
+                  SizedBox(height: 10),
+                  Row(
+                    children: [
+                      Text(
+                        '로그인',
+                        style: TextStyle(
+                          color: AppColors.grey[600],
+                          fontSize: 16,
+                          fontFamily: 'Pretendard',
+                          fontWeight: FontWeight.w400,
+                          height: 1.50,
+                        ),
+                      ),
+                      Spacer(),
+                      Text(
+                        loginProviderFormatter(data.loginProvider),
+                        style: TextStyle(
+                          color: AppColors.black,
+                          fontSize: 16,
+                          fontFamily: 'Pretendard',
+                          fontWeight: FontWeight.w400,
+                          height: 1.50,
+                        ),
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: 10),
+                  Row(
+                    children: [
+                      Text(
+                        '이메일',
+                        style: TextStyle(
+                          color: AppColors.grey[600],
+                          fontSize: 16,
+                          fontFamily: 'Pretendard',
+                          fontWeight: FontWeight.w400,
+                          height: 1.50,
+                        ),
+                      ),
+                      Spacer(),
+                      SizedBox(
+                        width: screenWidth * 0.7,
+                        child: Text(
+                          data.loginEmail ?? '',
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            color: AppColors.black,
+                            fontSize: 16,
+                            fontFamily: 'Pretendard',
+                            fontWeight: FontWeight.w400,
+                            height: 1.50,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+          loading: () => CircularProgressIndicator(),
+          error: (e, _) => Text('프로필 정보 불러오기 실패: $e'),
+        ),
       ),
     );
+  }
+
+  String loginProviderFormatter(String? provider) {
+    if (provider == null) return '';
+    String providerName = provider.split('.').first;
+    return '$providerName 로그인';
   }
 }

--- a/lib/views/my_page/widgets/account_info.dart
+++ b/lib/views/my_page/widgets/account_info.dart
@@ -91,6 +91,7 @@ class _AccountInfoState extends ConsumerState<AccountInfo> {
                         child: Text(
                           data.loginEmail ?? '',
                           overflow: TextOverflow.ellipsis,
+                          textAlign: TextAlign.right,
                           style: TextStyle(
                             color: AppColors.black,
                             fontSize: 16,


### PR DESCRIPTION
### 🚀: 개요
- 계정 관리 페이지 피그마 적용

### 🚀: 작업 내용
- 계정 관리 페이지 피그마 적용

### 📸: 실행 화면
<img src="https://github.com/user-attachments/assets/f0e767d9-0c9b-4fa7-bd53-6f06e31502b0" width="300" height="600"/>

### 🚀: 조정 파일
- lib/views/my_page/settings/account_setting_page.dart
- lib/views/my_page/widgets/account_info.dart

### 개발 결과
- 계정 관리 페이지 피그마 적용 완료

### issue
Closes #242
