### PR TITLE
[Etc] 텍스트폼필드 텍스트스타일 적용 및 전체 페이지 앱바 피그마 적용

### DIFF
--- a/assets/icons/more-vertical.svg
+++ b/assets/icons/more-vertical.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 13C12.5523 13 13 12.5523 13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12C11 12.5523 11.4477 13 12 13Z" stroke="#353A3C" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 6C12.5523 6 13 5.55228 13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5C11 5.55228 11.4477 6 12 6Z" stroke="#353A3C" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 20C12.5523 20 13 19.5523 13 19C13 18.4477 12.5523 18 12 18C11.4477 18 11 18.4477 11 19C11 19.5523 11.4477 20 12 20Z" stroke="#353A3C" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/lib/views/home/recommended_place/recommended_place_detail_page.dart
+++ b/lib/views/home/recommended_place/recommended_place_detail_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/models/home/home_place.dart';
 import 'package:travel_muse_app/providers/home/scrap_provider.dart';
@@ -20,8 +21,7 @@ class RecommendedPlaceDetailPage extends ConsumerStatefulWidget {
       _RecommendedPlaceDetailPageState();
 }
 
-class _RecommendedPlaceDetailPageState
-    extends ConsumerState<RecommendedPlaceDetailPage> {
+class _RecommendedPlaceDetailPageState extends ConsumerState<RecommendedPlaceDetailPage> {
   int _currentPage = 0;
   final PageController _pageController = PageController();
 
@@ -40,11 +40,7 @@ class _RecommendedPlaceDetailPageState
         title: Row(
           children: [
             IconButton(
-              icon: Icon(
-                Icons.chevron_left,
-                color: AppColors.grey[500],
-                size: 24,
-              ),
+              icon: Icon(Icons.chevron_left, color: AppColors.grey[500], size: 24),
               onPressed:
                   () => Navigator.pop(context, {
                     'title': place.title,
@@ -160,6 +156,7 @@ class _RecommendedPlaceDetailPageState
           ],
         ),
       ),
+      bottomNavigationBar: const BottomBar(),
     );
   }
 }

--- a/lib/views/home/recommended_place/recommended_place_detail_page.dart
+++ b/lib/views/home/recommended_place/recommended_place_detail_page.dart
@@ -39,16 +39,36 @@ class _RecommendedPlaceDetailPageState extends ConsumerState<RecommendedPlaceDet
         titleSpacing: 0,
         title: Row(
           children: [
-            IconButton(
-              icon: Icon(Icons.chevron_left, color: AppColors.grey[500], size: 24),
-              onPressed:
+            GestureDetector(
+              onTap:
                   () => Navigator.pop(context, {
                     'title': place.title,
                     'lat': place.latLng.latitude,
                     'lng': place.latLng.longitude,
                     'address': place.address,
                   }),
+              child: Container(
+                width: 44,
+                height: 44,
+                color: Colors.transparent,
+                child: SvgPicture.asset(
+                  'assets/icons/chevron-left.svg',
+                  width: 24,
+                  height: 24,
+                  fit: BoxFit.scaleDown,
+                ),
+              ),
             ),
+            // IconButton(
+            //   icon: Icon(Icons.chevron_left, color: AppColors.grey[500], size: 24),
+            //   onPressed:
+            //       () => Navigator.pop(context, {
+            //         'title': place.title,
+            //         'lat': place.latLng.latitude,
+            //         'lng': place.latLng.longitude,
+            //         'address': place.address,
+            //       }),
+            // ),
             Spacer(),
             Text(
               place.title,

--- a/lib/views/home/recommended_place/recommended_places_list_page.dart
+++ b/lib/views/home/recommended_place/recommended_places_list_page.dart
@@ -4,6 +4,7 @@ import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/providers/home/home_view_model_provider.dart';
 import 'package:travel_muse_app/views/home/recommended_place/widgets/recommended_place_list_card.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class RecommendedPlacesListPage extends ConsumerWidget {
   const RecommendedPlacesListPage({super.key});
@@ -14,20 +15,21 @@ class RecommendedPlacesListPage extends ConsumerWidget {
 
     return Scaffold(
       backgroundColor: AppColors.white,
-      appBar: AppBar(
-        title: const Text(
-          '추천 명소',
-          style: TextStyle(
-            color: AppColors.black,
-            fontSize: 18,
-            fontWeight: FontWeight.w700,
-            fontFamily: 'Pretendard',
-          ),
-        ),
-        backgroundColor: AppColors.white,
-        elevation: 1,
-        iconTheme: const IconThemeData(color: AppColors.black),
-      ),
+      appBar: CustomAppBar(title: '나의 여행'),
+      //  AppBar(
+      //   title: const Text(
+      //     '추천 명소',
+      //     style: TextStyle(
+      //       color: AppColors.black,
+      //       fontSize: 18,
+      //       fontWeight: FontWeight.w700,
+      //       fontFamily: 'Pretendard',
+      //     ),
+      //   ),
+      //   backgroundColor: AppColors.white,
+      //   elevation: 1,
+      //   iconTheme: const IconThemeData(color: AppColors.black),
+      // ),
       body: SafeArea(
         child: homeAsync.when(
           loading: () => const Center(child: CircularProgressIndicator()),
@@ -53,7 +55,7 @@ class RecommendedPlacesListPage extends ConsumerWidget {
                       isActive: true,
                       place: spot,
                     ),
-                Divider(height: 1, thickness: 0.5, color: AppColors.grey[200]),
+                    Divider(height: 1, thickness: 0.5, color: AppColors.grey[200]),
                   ],
                 );
               },

--- a/lib/views/home/recommended_place/recommended_places_list_page.dart
+++ b/lib/views/home/recommended_place/recommended_places_list_page.dart
@@ -16,20 +16,6 @@ class RecommendedPlacesListPage extends ConsumerWidget {
     return Scaffold(
       backgroundColor: AppColors.white,
       appBar: CustomAppBar(title: '나의 여행'),
-      //  AppBar(
-      //   title: const Text(
-      //     '추천 명소',
-      //     style: TextStyle(
-      //       color: AppColors.black,
-      //       fontSize: 18,
-      //       fontWeight: FontWeight.w700,
-      //       fontFamily: 'Pretendard',
-      //     ),
-      //   ),
-      //   backgroundColor: AppColors.white,
-      //   elevation: 1,
-      //   iconTheme: const IconThemeData(color: AppColors.black),
-      // ),
       body: SafeArea(
         child: homeAsync.when(
           loading: () => const Center(child: CircularProgressIndicator()),

--- a/lib/views/my_page/edit_profile_page.dart
+++ b/lib/views/my_page/edit_profile_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/providers/user/profile_view_model_provider.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 import 'package:travel_muse_app/views/widgets/edit_nickname.dart';
 import 'package:travel_muse_app/views/widgets/edit_profile_image.dart';
 import 'package:travel_muse_app/views/widgets/user_next_button.dart';
@@ -14,13 +15,7 @@ class EditProfilePage extends ConsumerWidget {
     final state = ref.watch(profileViewModelProvider);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text(
-          '프로필 수정',
-          style: TextStyle(fontWeight: FontWeight.bold),
-        ),
-        centerTitle: false,
-      ),
+      appBar: CustomAppBar(title: '프로필 수정'),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 20),
         child: Stack(

--- a/lib/views/my_page/like_list_page.dart
+++ b/lib/views/my_page/like_list_page.dart
@@ -2,12 +2,12 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
-import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/models/post/post_model.dart';
 import 'package:travel_muse_app/providers/post/like_provider.dart';
 import 'package:travel_muse_app/views/post/post_detail_page.dart';
 import 'package:travel_muse_app/views/post/widgets/list/post_item.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class LikeListPage extends ConsumerStatefulWidget {
   const LikeListPage({super.key});
@@ -36,10 +36,7 @@ class _LikeListPageState extends ConsumerState<LikeListPage> {
     final likeRepository = ref.read(likeRepositoryProvider);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('좋아요한 게시글', style: AppTextStyles.appBarTitle),
-        centerTitle: false,
-      ),
+      appBar: CustomAppBar(title: '좋아요한 게시글'),
       body: FutureBuilder<List<Post>>(
         future: likeRepository.fetchLikedPosts(userId!),
         builder: (context, snapshot) {
@@ -52,9 +49,7 @@ class _LikeListPageState extends ConsumerState<LikeListPage> {
           }
 
           final posts =
-              (snapshot.data ?? [])
-                  .where((post) => post.isDeleted == false)
-                  .toList();
+              (snapshot.data ?? []).where((post) => post.isDeleted == false).toList();
 
           if (posts.isEmpty) {
             return const Center(child: Text('좋아요한 게시글이 없습니다.'));
@@ -72,9 +67,7 @@ class _LikeListPageState extends ConsumerState<LikeListPage> {
                 onTap: () async {
                   final result = await Navigator.push(
                     context,
-                    MaterialPageRoute(
-                      builder: (_) => PostDetailPage(post: post),
-                    ),
+                    MaterialPageRoute(builder: (_) => PostDetailPage(post: post)),
                   );
 
                   if (mounted) setState(() {}); // 좋아요 취소 시 목록 갱신
@@ -85,10 +78,7 @@ class _LikeListPageState extends ConsumerState<LikeListPage> {
                   decoration: ShapeDecoration(
                     color: AppColors.white,
                     shape: RoundedRectangleBorder(
-                      side: BorderSide(
-                        width: 0.20,
-                        color: AppColors.grey[200]!,
-                      ),
+                      side: BorderSide(width: 0.20, color: AppColors.grey[200]!),
                     ),
                   ),
                   child: PostItem(screenWidth: screenWidth, post: post),

--- a/lib/views/my_page/my_page.dart
+++ b/lib/views/my_page/my_page.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
-import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/views/my_page/widgets/my_page_menu.dart';
 import 'package:travel_muse_app/views/my_page/widgets/my_profile_screen.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class MyPage extends StatelessWidget {
   const MyPage({super.key});
@@ -12,10 +12,7 @@ class MyPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: AppColors.white,
-      appBar: AppBar(
-        title: Text('마이페이지', style: AppTextStyles.appBarTitle),
-        centerTitle: false,
-      ),
+      appBar: CustomAppBar(title: '마이페이지'),
       body: SafeArea(
         child: SingleChildScrollView(
           child: Column(

--- a/lib/views/my_page/my_post_page.dart
+++ b/lib/views/my_page/my_post_page.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
-import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/providers/post/my_posts_view_model_provider.dart';
 import 'package:travel_muse_app/views/post/post_detail_page.dart';
 import 'package:travel_muse_app/views/post/widgets/list/post_item.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class MyPostPage extends ConsumerWidget {
   const MyPostPage({super.key});
@@ -16,14 +16,10 @@ class MyPostPage extends ConsumerWidget {
     final screenWidth = MediaQuery.of(context).size.width;
 
     return Scaffold(
-      appBar: AppBar(
-        title: Text('내 게시물', style: AppTextStyles.appBarTitle),
-        centerTitle: false,
-      ),
+      appBar: CustomAppBar(title: '내 게시물'),
       body: postAsync.when(
         data: (data) {
-          final filtered =
-              data.where((post) => post.isDeleted == false).toList();
+          final filtered = data.where((post) => post.isDeleted == false).toList();
 
           if (filtered.isEmpty) {
             return const Center(child: Text('작성한 게시물이 없습니다.'));
@@ -36,9 +32,7 @@ class MyPostPage extends ConsumerWidget {
                 onTap: () {
                   Navigator.push(
                     context,
-                    MaterialPageRoute(
-                      builder: (context) => PostDetailPage(post: post),
-                    ),
+                    MaterialPageRoute(builder: (context) => PostDetailPage(post: post)),
                   );
                 },
                 child: Container(
@@ -47,10 +41,7 @@ class MyPostPage extends ConsumerWidget {
                   decoration: ShapeDecoration(
                     color: AppColors.white,
                     shape: RoundedRectangleBorder(
-                      side: BorderSide(
-                        width: 0.20,
-                        color: AppColors.grey[200]!,
-                      ),
+                      side: BorderSide(width: 0.20, color: AppColors.grey[200]!),
                     ),
                   ),
                   child: PostItem(screenWidth: screenWidth, post: post),

--- a/lib/views/my_page/my_scrap_list_page.dart
+++ b/lib/views/my_page/my_scrap_list_page.dart
@@ -5,6 +5,7 @@ import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/providers/home/scrap_provider.dart';
 import 'package:travel_muse_app/views/my_page/widgets/confirm_dialog.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class MyScrapListPage extends ConsumerWidget {
   const MyScrapListPage({super.key});
@@ -15,7 +16,7 @@ class MyScrapListPage extends ConsumerWidget {
     final state = ref.watch(scrapListViewModelProvider);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('북마크'), centerTitle: false, elevation: 0),
+      appBar: CustomAppBar(title: '북마크'),
       body: state.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (err, _) => Center(child: Text('에러 발생: $err')),

--- a/lib/views/my_page/my_scrap_list_page.dart
+++ b/lib/views/my_page/my_scrap_list_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/providers/home/scrap_provider.dart';
 import 'package:travel_muse_app/views/my_page/widgets/confirm_dialog.dart';
@@ -14,11 +15,7 @@ class MyScrapListPage extends ConsumerWidget {
     final state = ref.watch(scrapListViewModelProvider);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('북마크'),
-        centerTitle: false,
-        elevation: 0,
-      ),
+      appBar: AppBar(title: const Text('북마크'), centerTitle: false, elevation: 0),
       body: state.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (err, _) => Center(child: Text('에러 발생: $err')),
@@ -29,11 +26,8 @@ class MyScrapListPage extends ConsumerWidget {
 
           return ListView.separated(
             itemCount: places.length,
-            separatorBuilder: (_, __) => Divider(
-              height: 1,
-              thickness: 0.5,
-              color: AppColors.grey[200],
-            ),
+            separatorBuilder:
+                (_, __) => Divider(height: 1, thickness: 0.5, color: AppColors.grey[200]),
             itemBuilder: (context, index) {
               final place = places[index];
               return Padding(
@@ -83,27 +77,19 @@ class MyScrapListPage extends ConsumerWidget {
                             place.category,
                             overflow: TextOverflow.ellipsis,
                             maxLines: 1,
-                            style: TextStyle(
-                              fontSize: 14,
-                              color: AppColors.grey[400],
-                            ),
+                            style: TextStyle(fontSize: 14, color: AppColors.grey[400]),
                           ),
                         ],
                       ),
                     ),
                     IconButton(
                       iconSize: 24,
-                      icon: Icon(
-                        Icons.bookmark,
-                        color: AppColors.primary[300],
-                      ),
+                      icon: Icon(Icons.bookmark, color: AppColors.primary[300]),
                       onPressed: () async {
                         final confirm = await _showDeleteDialog(context);
                         if (confirm != true) return;
 
-                        await ref
-                            .read(scrapListViewModelProvider.notifier)
-                            .remove(place);
+                        await ref.read(scrapListViewModelProvider.notifier).remove(place);
 
                         CustomToast.show(
                           context: context,
@@ -119,6 +105,7 @@ class MyScrapListPage extends ConsumerWidget {
           );
         },
       ),
+      bottomNavigationBar: const BottomBar(),
     );
   }
 }
@@ -126,10 +113,11 @@ class MyScrapListPage extends ConsumerWidget {
 Future<bool?> _showDeleteDialog(BuildContext context) {
   return showDialog<bool>(
     context: context,
-    builder: (context) => const ConfirmDialog(
-      title: '스크랩을 해제하시겠습니까?',
-      description: '스크랩을 삭제하고 후에는 되돌릴 수 없어요',
-    ),
+    builder:
+        (context) => const ConfirmDialog(
+          title: '스크랩을 해제하시겠습니까?',
+          description: '스크랩을 삭제하고 후에는 되돌릴 수 없어요',
+        ),
   );
 }
 

--- a/lib/views/my_page/plan_list_page.dart
+++ b/lib/views/my_page/plan_list_page.dart
@@ -2,7 +2,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
-import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/providers/plan/schedule/schedule_provider.dart';
@@ -13,6 +12,7 @@ import 'package:travel_muse_app/viewmodels/plan/schedule_view_model.dart';
 import 'package:travel_muse_app/views/my_page/widgets/confirm_dialog.dart';
 import 'package:travel_muse_app/views/my_page/widgets/my_page_list_item.dart';
 import 'package:travel_muse_app/views/plan/plan/schedule/schedule_page.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class PlanListPage extends ConsumerStatefulWidget {
   const PlanListPage({super.key});
@@ -66,10 +66,7 @@ class _PlanListPageState extends ConsumerState<PlanListPage> {
     final savedPlans = plans != null ? plans.savedPlans : [];
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('나의 여행', style: AppTextStyles.appBarTitle),
-        centerTitle: false,
-      ),
+      appBar: CustomAppBar(title: '나의 여행'),
       body: SafeArea(
         child:
             savedPlans.isEmpty

--- a/lib/views/my_page/preference_list_page.dart
+++ b/lib/views/my_page/preference_list_page.dart
@@ -7,6 +7,7 @@ import 'package:travel_muse_app/providers/preference/preference_test_provider.da
 import 'package:travel_muse_app/providers/user/profile_view_model_provider.dart';
 import 'package:travel_muse_app/views/my_page/widgets/my_page_list_item.dart';
 import 'package:travel_muse_app/views/preference/widgets/result_view.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class PreferenceListPage extends ConsumerStatefulWidget {
   const PreferenceListPage({super.key});
@@ -35,12 +36,7 @@ class _PreferenceListPageState extends ConsumerState<PreferenceListPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text(
-          '나의 성향',
-          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-        ),
-      ),
+      appBar: CustomAppBar(title: '나의 여행 성향'),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(10),
@@ -69,10 +65,7 @@ class _PreferenceListPageState extends ConsumerState<PreferenceListPage> {
                           if (result == 'deleted') {
                             final tests =
                                 await ref
-                                    .read(
-                                      preferenceTestStateNotifierProvider
-                                          .notifier,
-                                    )
+                                    .read(preferenceTestStateNotifierProvider.notifier)
                                     .fetchTestsByUserId();
                             setState(() {
                               _tests = tests;

--- a/lib/views/my_page/settings/account_setting_page.dart
+++ b/lib/views/my_page/settings/account_setting_page.dart
@@ -7,6 +7,7 @@ import 'package:travel_muse_app/views/my_page/widgets/account_info.dart';
 import 'package:travel_muse_app/views/my_page/widgets/confirm_dialog.dart';
 import 'package:travel_muse_app/views/my_page/widgets/my_profile_screen.dart';
 import 'package:travel_muse_app/views/user/login/login_page.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class AccountSettingPage extends ConsumerStatefulWidget {
   const AccountSettingPage({super.key});
@@ -19,19 +20,7 @@ class _AccountSettingPageState extends ConsumerState<AccountSettingPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text(
-          '계정 관리',
-          style: TextStyle(
-            color: Colors.black,
-            fontFamily: 'Pretendard',
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        backgroundColor: Colors.white,
-        elevation: 0,
-        iconTheme: const IconThemeData(color: Colors.black),
-      ),
+      appBar: CustomAppBar(title: '계정 관리'),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/lib/views/my_page/settings/environment_setting_page.dart
+++ b/lib/views/my_page/settings/environment_setting_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 
 class EnvironmentSettingPage extends StatelessWidget {
   const EnvironmentSettingPage({super.key});
@@ -37,9 +38,7 @@ class EnvironmentSettingPage extends StatelessWidget {
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
               decoration: BoxDecoration(
-                border: Border(
-                  bottom: BorderSide(width: 1, color: AppColors.grey[50]!),
-                ),
+                border: Border(bottom: BorderSide(width: 1, color: AppColors.grey[50]!)),
               ),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -59,17 +58,14 @@ class EnvironmentSettingPage extends StatelessWidget {
                       ),
                     ),
                   ),
-                  Icon(
-                    Icons.arrow_forward_ios,
-                    size: 16,
-                    color: AppColors.grey[600],
-                  ),
+                  Icon(Icons.arrow_forward_ios, size: 16, color: AppColors.grey[600]),
                 ],
               ),
             ),
           );
         },
       ),
+      bottomNavigationBar: const BottomBar(),
     );
   }
 }

--- a/lib/views/my_page/settings/environment_setting_page.dart
+++ b/lib/views/my_page/settings/environment_setting_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class EnvironmentSettingPage extends StatelessWidget {
   const EnvironmentSettingPage({super.key});
@@ -17,19 +18,7 @@ class EnvironmentSettingPage extends StatelessWidget {
     ];
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text(
-          '서비스 약관',
-          style: TextStyle(
-            color: Colors.black,
-            fontFamily: 'Pretendard',
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        backgroundColor: Colors.white,
-        elevation: 0,
-        iconTheme: const IconThemeData(color: Colors.black),
-      ),
+      appBar: CustomAppBar(title: '환경 설정'),
       body: ListView.builder(
         itemCount: settingsItems.length,
         itemBuilder: (context, index) {

--- a/lib/views/my_page/settings/notification_setting_page.dart
+++ b/lib/views/my_page/settings/notification_setting_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/utills/notification_helper.dart';
 import 'package:travel_muse_app/utills/notification_setting.dart'; // SharedPreferences 저장소
 
@@ -7,8 +8,7 @@ class NotificationSettingPage extends StatefulWidget {
   const NotificationSettingPage({super.key});
 
   @override
-  State<NotificationSettingPage> createState() =>
-      _NotificationSettingPageState();
+  State<NotificationSettingPage> createState() => _NotificationSettingPageState();
 }
 
 class _NotificationSettingPageState extends State<NotificationSettingPage> {
@@ -128,16 +128,10 @@ class _NotificationSettingPageState extends State<NotificationSettingPage> {
                   final item = settingsItems[index];
                   final value = _switchValues[item] ?? true;
                   return Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 16,
-                      vertical: 16,
-                    ),
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
                     decoration: BoxDecoration(
                       border: Border(
-                        bottom: BorderSide(
-                          width: 1,
-                          color: AppColors.grey[50]!,
-                        ),
+                        bottom: BorderSide(width: 1, color: AppColors.grey[50]!),
                       ),
                     ),
                     child: Row(
@@ -168,6 +162,7 @@ class _NotificationSettingPageState extends State<NotificationSettingPage> {
                   );
                 },
               ),
+      bottomNavigationBar: const BottomBar(),
     );
   }
 }

--- a/lib/views/my_page/settings/notification_setting_page.dart
+++ b/lib/views/my_page/settings/notification_setting_page.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/utills/notification_helper.dart';
-import 'package:travel_muse_app/utills/notification_setting.dart'; // SharedPreferences 저장소
+import 'package:travel_muse_app/utills/notification_setting.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart'; // SharedPreferences 저장소
 
 class NotificationSettingPage extends StatefulWidget {
   const NotificationSettingPage({super.key});
@@ -106,19 +107,7 @@ class _NotificationSettingPageState extends State<NotificationSettingPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text(
-          '알림 설정',
-          style: TextStyle(
-            color: Colors.black,
-            fontFamily: 'Pretendard',
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        backgroundColor: Colors.white,
-        elevation: 0,
-        iconTheme: const IconThemeData(color: Colors.black),
-      ),
+      appBar: CustomAppBar(title: '알림 설정'),
       body:
           _switchValues.length < settingsItems.length
               ? const Center(child: CircularProgressIndicator())

--- a/lib/views/my_page/settings/service_term_page.dart
+++ b/lib/views/my_page/settings/service_term_page.dart
@@ -1,29 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/views/user/onboarding/terms_web_view_page.dart';
 
 final List<Map<String, String>> termsData = [
   {'title': '만 14세 이상입니다.', 'url': ''},
-  {
-    'title': '서비스 이용약관',
-    'url': 'https://www.notion.so/21cc9d67bce980ab9579ebf380ad5d2c',
-  },
-  {
-    'title': '개인정보 처리방침',
-    'url': 'https://www.notion.so/21cc9d67bce980d58f34ec20ee46d139',
-  },
+  {'title': '서비스 이용약관', 'url': 'https://www.notion.so/21cc9d67bce980ab9579ebf380ad5d2c'},
+  {'title': '개인정보 처리방침', 'url': 'https://www.notion.so/21cc9d67bce980d58f34ec20ee46d139'},
   {
     'title': '마케팅 수신 동의',
     'url': 'https://www.notion.so/21cc9d67bce980ab9579ebf380ad5d2c?pvs=12',
   },
-  {
-    'title': '커뮤니티 운영정책',
-    'url': 'https://www.notion.so/21cc9d67bce980b1a257c3a7dcf39cc2',
-  },
-  {
-    'title': '위치정보 이용동의',
-    'url': 'https://www.notion.so/21cc9d67bce9802e92f5fbaceffe6190',
-  },
+  {'title': '커뮤니티 운영정책', 'url': 'https://www.notion.so/21cc9d67bce980b1a257c3a7dcf39cc2'},
+  {'title': '위치정보 이용동의', 'url': 'https://www.notion.so/21cc9d67bce9802e92f5fbaceffe6190'},
 ];
 
 class ServiceTermPage extends StatelessWidget {
@@ -68,9 +57,7 @@ class ServiceTermPage extends StatelessWidget {
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
               decoration: BoxDecoration(
-                border: Border(
-                  bottom: BorderSide(width: 1, color: AppColors.grey[50]!),
-                ),
+                border: Border(bottom: BorderSide(width: 1, color: AppColors.grey[50]!)),
               ),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -103,6 +90,7 @@ class ServiceTermPage extends StatelessWidget {
           );
         },
       ),
+      bottomNavigationBar: const BottomBar(),
     );
   }
 }

--- a/lib/views/my_page/settings/service_term_page.dart
+++ b/lib/views/my_page/settings/service_term_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/views/user/onboarding/terms_web_view_page.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 final List<Map<String, String>> termsData = [
   {'title': '만 14세 이상입니다.', 'url': ''},
@@ -21,19 +22,7 @@ class ServiceTermPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text(
-          '서비스 약관',
-          style: TextStyle(
-            color: Colors.black,
-            fontFamily: 'Pretendard',
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        backgroundColor: Colors.white,
-        elevation: 0,
-        iconTheme: const IconThemeData(color: Colors.black),
-      ),
+      appBar: CustomAppBar(title: '서비스 약관'),
       body: ListView.builder(
         itemCount: termsData.length,
         itemBuilder: (context, index) {

--- a/lib/views/my_page/settings/setting_page.dart
+++ b/lib/views/my_page/settings/setting_page.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/views/my_page/settings/account_setting_page.dart';
 import 'package:travel_muse_app/views/my_page/settings/environment_setting_page.dart';
 import 'package:travel_muse_app/views/my_page/settings/notification_setting_page.dart';
@@ -51,10 +52,8 @@ class _SettingPageState extends State<SettingPage> {
       {'title': '서비스 약관', 'route': const ServiceTermPage()},
       {'title': '고객 지원', 'route': const SupportPage()},
       {'title': '버전 정보', 'route': const VersionPage()},
-      if (_isAdmin)
-        {'title': '운영자 권한 설정', 'route': const AdminEntry()},
-      if (_isAdmin)
-        {'title': '신고 컨텐츠 관리', 'route': const AdminReportEntry()},
+      if (_isAdmin) {'title': '운영자 권한 설정', 'route': const AdminEntry()},
+      if (_isAdmin) {'title': '신고 컨텐츠 관리', 'route': const AdminReportEntry()},
     ];
 
     return Scaffold(
@@ -78,17 +77,13 @@ class _SettingPageState extends State<SettingPage> {
             onTap: () {
               Navigator.push(
                 context,
-                MaterialPageRoute(
-                  builder: (_) => settingsItems[index]['route'],
-                ),
+                MaterialPageRoute(builder: (_) => settingsItems[index]['route']),
               );
             },
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
               decoration: BoxDecoration(
-                border: Border(
-                  bottom: BorderSide(width: 1, color: AppColors.grey[50]!),
-                ),
+                border: Border(bottom: BorderSide(width: 1, color: AppColors.grey[50]!)),
               ),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -108,17 +103,14 @@ class _SettingPageState extends State<SettingPage> {
                       ),
                     ),
                   ),
-                  Icon(
-                    Icons.arrow_forward_ios,
-                    size: 16,
-                    color: AppColors.grey[600],
-                  ),
+                  Icon(Icons.arrow_forward_ios, size: 16, color: AppColors.grey[600]),
                 ],
               ),
             ),
           );
         },
       ),
+      bottomNavigationBar: const BottomBar(),
     );
   }
 }

--- a/lib/views/my_page/settings/setting_page.dart
+++ b/lib/views/my_page/settings/setting_page.dart
@@ -10,6 +10,7 @@ import 'package:travel_muse_app/views/my_page/settings/support_page.dart';
 import 'package:travel_muse_app/views/my_page/settings/version_page.dart';
 import 'package:travel_muse_app/views/user/admin/admin_entry.dart';
 import 'package:travel_muse_app/views/user/admin/admin_report_entry.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class SettingPage extends StatefulWidget {
   const SettingPage({super.key});
@@ -57,19 +58,7 @@ class _SettingPageState extends State<SettingPage> {
     ];
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text(
-          '설정',
-          style: TextStyle(
-            color: Colors.black,
-            fontFamily: 'Pretendard',
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        backgroundColor: Colors.white,
-        elevation: 0,
-        iconTheme: const IconThemeData(color: Colors.black),
-      ),
+      appBar: CustomAppBar(title: '설정'),
       body: ListView.builder(
         itemCount: settingsItems.length,
         itemBuilder: (context, index) {

--- a/lib/views/my_page/settings/support_page.dart
+++ b/lib/views/my_page/settings/support_page.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class SupportPage extends StatelessWidget {
   const SupportPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(appBar: AppBar(title: Text('고객 지원')), body: Text('고객 지원'));
+    return Scaffold(appBar: CustomAppBar(title: '고객 지원'), body: Text('고객 지원'));
   }
 }

--- a/lib/views/my_page/settings/version_page.dart
+++ b/lib/views/my_page/settings/version_page.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class VersionPage extends StatelessWidget {
   const VersionPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(appBar: AppBar(title: Text('버전 정보')), body: Text('버전 정보'));
+    return Scaffold(appBar: CustomAppBar(title: '버전 정보'), body: Text('버전 정보'));
   }
 }

--- a/lib/views/plan/location/map_page.dart
+++ b/lib/views/plan/location/map_page.dart
@@ -7,8 +7,8 @@ import 'package:travel_muse_app/utills/map_utils.dart';
 import 'package:travel_muse_app/viewmodels/plan/map_view_model.dart';
 import 'package:travel_muse_app/views/plan/location/widgets/day_tab_bar.dart';
 import 'package:travel_muse_app/views/plan/location/widgets/map_display.dart';
-import 'package:travel_muse_app/views/plan/location/widgets/map_page_app_bar.dart';
 import 'package:travel_muse_app/views/plan/location/widgets/place_carousel.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class MapPage extends ConsumerStatefulWidget {
   const MapPage({super.key, required this.planId});
@@ -17,8 +17,7 @@ class MapPage extends ConsumerStatefulWidget {
   ConsumerState<MapPage> createState() => _MapPageState();
 }
 
-class _MapPageState extends ConsumerState<MapPage>
-    with TickerProviderStateMixin {
+class _MapPageState extends ConsumerState<MapPage> with TickerProviderStateMixin {
   GoogleMapController? _mapController;
   bool _cameraMoved = false;
   LatLng _initialLatLng = const LatLng(33.4996, 126.5312);
@@ -36,8 +35,7 @@ class _MapPageState extends ConsumerState<MapPage>
         final allPlaces = _viewModel.getAllPlaces();
         _viewModel.moveCameraToFitAll(_mapController, allPlaces);
       } else {
-        final newPlaces =
-            mapState.dayPlaces[dayKeys[_tabController!.index - 1]] ?? [];
+        final newPlaces = mapState.dayPlaces[dayKeys[_tabController!.index - 1]] ?? [];
         _viewModel.moveCameraToFitAll(_mapController, newPlaces);
       }
     }
@@ -118,7 +116,7 @@ class _MapPageState extends ConsumerState<MapPage>
     );
     final displayDayTabs = ['All', ...dayKeys.map(getDisplayDayTab)];
     return Scaffold(
-      appBar: MapPageAppBar(),
+      appBar: CustomAppBar(title: '지도'),
       body: Column(
         children: [
           Expanded(
@@ -130,10 +128,7 @@ class _MapPageState extends ConsumerState<MapPage>
                 _mapController = controller;
                 if (!_cameraMoved && selectedPlaces.isNotEmpty) {
                   Future.delayed(const Duration(milliseconds: 300), () {
-                    _viewModel.moveCameraToFitAll(
-                      _mapController,
-                      selectedPlaces,
-                    );
+                    _viewModel.moveCameraToFitAll(_mapController, selectedPlaces);
                     _cameraMoved = true;
                   });
                 }

--- a/lib/views/plan/plan/calendar/calendar_page.dart
+++ b/lib/views/plan/plan/calendar/calendar_page.dart
@@ -6,6 +6,7 @@ import 'package:travel_muse_app/utills/date_utils.dart';
 import 'package:travel_muse_app/views/plan/plan/calendar/widgets/calendar_guide_text.dart';
 import 'package:travel_muse_app/views/plan/plan/calendar/widgets/calendar_widget.dart';
 import 'package:travel_muse_app/views/plan/plan/location_setting/province_setting_page.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class CalendarPage extends ConsumerWidget {
   const CalendarPage({super.key});
@@ -16,15 +17,7 @@ class CalendarPage extends ConsumerWidget {
     final state = ref.watch(calendarViewModelProvider);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text(
-          '여행 일정 등록',
-          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
-        ),
-        backgroundColor: Colors.white,
-        foregroundColor: Colors.grey[800],
-        elevation: 0,
-      ),
+      appBar: CustomAppBar(title: '여행 일정 등록'),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16),
@@ -40,8 +33,7 @@ class CalendarPage extends ConsumerWidget {
                     final year =
                         state.focusedDay.year +
                         ((state.focusedDay.month + index - 1) ~/ 12);
-                    final month =
-                        ((state.focusedDay.month + index - 1) % 12) + 1;
+                    final month = ((state.focusedDay.month + index - 1) % 12) + 1;
 
                     final focusedMonth = DateTime(year, month);
 
@@ -68,9 +60,7 @@ class CalendarPage extends ConsumerWidget {
                     ),
                   ),
                   onPressed: () {
-                    final viewModel = ref.read(
-                      calendarViewModelProvider.notifier,
-                    );
+                    final viewModel = ref.read(calendarViewModelProvider.notifier);
                     final state = ref.read(calendarViewModelProvider);
 
                     final start = state.startDay;
@@ -86,9 +76,9 @@ class CalendarPage extends ConsumerWidget {
                         ),
                       );
                     } else {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('여행 날짜를 선택해주세요.')),
-                      );
+                      ScaffoldMessenger.of(
+                        context,
+                      ).showSnackBar(const SnackBar(content: Text('여행 날짜를 선택해주세요.')));
                     }
                   },
 

--- a/lib/views/plan/plan/location_setting/district_setting_page.dart
+++ b/lib/views/plan/plan/location_setting/district_setting_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/utills/region_data.dart';
 import 'package:travel_muse_app/views/plan/plan/location_setting/widgets/district_box_list.dart';
 import 'package:travel_muse_app/views/plan/plan/location_setting/widgets/save_button.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class DistrictSettingPage extends ConsumerStatefulWidget {
   const DistrictSettingPage({super.key, required this.selectedProvince});
@@ -26,15 +27,7 @@ class DistrictSettingPageState extends ConsumerState<DistrictSettingPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.white,
-      appBar: AppBar(
-        title: const Text(
-          '여행 일정 등록',
-          style: TextStyle(fontWeight: FontWeight.bold),
-        ),
-        backgroundColor: Colors.white,
-        foregroundColor: Colors.black,
-        elevation: 0.5,
-      ),
+      appBar: CustomAppBar(title: '여행 일정 등록'),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16),
@@ -51,8 +44,7 @@ class DistrictSettingPageState extends ConsumerState<DistrictSettingPage> {
               Expanded(
                 child: DistrictBoxList(
                   items: districts,
-                  selectedIndices:
-                      selectedIndex != null ? {selectedIndex!} : {},
+                  selectedIndices: selectedIndex != null ? {selectedIndex!} : {},
                   onTap: (index) {
                     setState(() {
                       selectedIndex = index;

--- a/lib/views/plan/plan/location_setting/province_setting_page.dart
+++ b/lib/views/plan/plan/location_setting/province_setting_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/utills/region_data.dart';
 import 'package:travel_muse_app/views/plan/plan/location_setting/widgets/next_button.dart';
 import 'package:travel_muse_app/views/plan/plan/location_setting/widgets/province_box_list.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class ProvinceSettingPage extends ConsumerStatefulWidget {
   const ProvinceSettingPage({super.key});
@@ -18,16 +19,17 @@ class ProvinceSettingPageState extends ConsumerState<ProvinceSettingPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.white,
-      appBar: AppBar(
-        title: Text(
-          '여행 일정 등록',
-          style: TextStyle(
-            fontWeight: FontWeight.bold,
-            color: Colors.grey[800],
-          ),
-        ),
-        backgroundColor: Colors.white,
-      ),
+      appBar: CustomAppBar(title: '여행 일정 등록'),
+      // AppBar(
+      //   title: Text(
+      //     '여행 일정 등록',
+      //     style: TextStyle(
+      //       fontWeight: FontWeight.bold,
+      //       color: Colors.grey[800],
+      //     ),
+      //   ),
+      //   backgroundColor: Colors.white,
+      // ),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(16),
@@ -45,8 +47,7 @@ class ProvinceSettingPageState extends ConsumerState<ProvinceSettingPage> {
                 child: ProvinceBoxList(
                   items: provinces,
                   emojis: emojis,
-                  selectedIndices:
-                      selectedIndex != null ? {selectedIndex!} : {},
+                  selectedIndices: selectedIndex != null ? {selectedIndex!} : {},
                   onTap: (index) {
                     setState(() {
                       selectedIndex = index;

--- a/lib/views/plan/plan/widgets/schedule_app_bar.dart
+++ b/lib/views/plan/plan/widgets/schedule_app_bar.dart
@@ -15,9 +15,8 @@ class ScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return AppBar(
-      leading: IconButton(
-        icon: const Icon(Icons.chevron_left),
-        onPressed: () async {
+      leading: GestureDetector(
+        onTap: () async {
           final shouldPop = await showDialog<bool>(
             context: context,
             builder:
@@ -31,8 +30,36 @@ class ScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
             Navigator.of(context).pop();
           }
         },
+        child: Container(
+          width: 44,
+          height: 44,
+          color: Colors.transparent,
+          child: SvgPicture.asset(
+            'assets/icons/chevron-left.svg',
+            width: 24,
+            height: 24,
+            fit: BoxFit.scaleDown,
+          ),
+        ),
       ),
 
+      // IconButton(
+      //   icon: const Icon(Icons.chevron_left),
+      //   onPressed: () async {
+      //     final shouldPop = await showDialog<bool>(
+      //       context: context,
+      //       builder:
+      //           (context) => const ScheduleConfirmDialog(
+      //             title: '일정 등록 화면에서 나가시겠습니까?',
+      //             description: '지금 나가면 일정이 저장되지 않아요',
+      //           ),
+      //     );
+
+      //     if (shouldPop == true) {
+      //       Navigator.of(context).pop();
+      //     }
+      //   },
+      // ),
       title: Text(
         '여행 일정 등록',
         style: TextStyle(
@@ -47,11 +74,7 @@ class ScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
         Padding(
           padding: const EdgeInsets.only(right: 16),
           child: GestureDetector(
-            child: SvgPicture.asset(
-              'assets/icons/map.svg',
-              width: 28,
-              height: 28,
-            ),
+            child: SvgPicture.asset('assets/icons/map.svg', width: 28, height: 28),
             onTap: () async {
               final hasRoute = await ref
                   .read(scheduleViewModelProvider.notifier)
@@ -60,10 +83,10 @@ class ScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
               if (!hasRoute) {
                 if (context.mounted) {
                   CustomToast.show(
-                                context: context,
-                                message: '일정을 먼저 등록해주세요.',
-                                duration: const Duration(seconds: 2),
-                              );
+                    context: context,
+                    message: '일정을 먼저 등록해주세요.',
+                    duration: const Duration(seconds: 2),
+                  );
                 }
                 return;
               }

--- a/lib/views/post/post_detail_page.dart
+++ b/lib/views/post/post_detail_page.dart
@@ -3,13 +3,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/models/post/post_model.dart';
 import 'package:travel_muse_app/providers/post/like_provider.dart';
 import 'package:travel_muse_app/providers/post/post_provider.dart';
 import 'package:travel_muse_app/providers/scoial/report_provider.dart';
-import 'package:travel_muse_app/views/post/post_write_page.dart';
 import 'package:travel_muse_app/views/post/%08comment/comment_section.dart';
+import 'package:travel_muse_app/views/post/post_write_page.dart';
 import 'package:travel_muse_app/views/post/widgets/detail/place_preview_card.dart';
 import 'package:travel_muse_app/views/post/widgets/detail/popup.dart';
 import 'package:travel_muse_app/views/post/widgets/detail/post_detail_appbar.dart';
@@ -20,12 +21,7 @@ import 'package:travel_muse_app/views/post/widgets/detail/post_detail_tags_and_m
 import 'package:travel_muse_app/views/post/widgets/detail/show_report_reason_dialog.dart';
 
 class PostDetailPage extends ConsumerStatefulWidget {
-  const PostDetailPage({
-    super.key,
-    this.post,
-    this.postId,
-    this.scrollToCommentId,
-  });
+  const PostDetailPage({super.key, this.post, this.postId, this.scrollToCommentId});
 
   final Post? post;
   final String? postId;
@@ -200,10 +196,7 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
                         ),
                         onTap: () {
                           Navigator.pop(context);
-                          showReportReasonDialog(context, (
-                            reasonCode,
-                            reasonText,
-                          ) async {
+                          showReportReasonDialog(context, (reasonCode, reasonText) async {
                             await ref
                                 .read(reportViewModelProvider.notifier)
                                 .submit(
@@ -267,10 +260,7 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
             children: [
               PostDetailHeader(nickname: nickname, profileUrl: profileUrl),
               const SizedBox(height: 16),
-              PostDetailContent(
-                title: currentPost.title,
-                content: currentPost.content,
-              ),
+              PostDetailContent(title: currentPost.title, content: currentPost.content),
               const SizedBox(height: 16),
               PostDetailImages(images: currentPost.images),
               const SizedBox(height: 16),
@@ -290,10 +280,7 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
                 likeCount: currentPost.likeCount,
                 isLiked: ref.watch(
                   likeViewModelProvider(
-                    LikeViewModelParams(
-                      postId: currentPost.postId,
-                      userId: user.uid,
-                    ),
+                    LikeViewModelParams(postId: currentPost.postId, userId: user.uid),
                   ),
                 ),
                 onLikePressed: () async {
@@ -302,9 +289,7 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
                     userId: user.uid,
                   );
 
-                  final likeVM = ref.read(
-                    likeViewModelProvider(params).notifier,
-                  );
+                  final likeVM = ref.read(likeViewModelProvider(params).notifier);
 
                   await likeVM.toggleLike();
 
@@ -316,6 +301,7 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
             ],
           ),
         ),
+        bottomNavigationBar: const BottomBar(),
       ),
     );
   }

--- a/lib/views/post/post_list_page.dart
+++ b/lib/views/post/post_list_page.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
-import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/views/post/widgets/list/post_list_view.dart';
 import 'package:travel_muse_app/views/post/widgets/list/post_search_page.dart';
 import 'package:travel_muse_app/views/post/widgets/list/tag_bar.dart';
 import 'package:travel_muse_app/views/post/widgets/write/write_fab.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class PostListPage extends StatefulWidget {
   const PostListPage({super.key});
@@ -21,25 +21,8 @@ class _PostListPageState extends State<PostListPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('커뮤니티'),
-        centerTitle: false,
-        titleTextStyle: AppTextStyles.appBarTitle,
-        leading: Padding(
-          padding: const EdgeInsets.only(top: 5),
-          child: Center(
-            child: IconButton(
-              icon: SvgPicture.asset(
-                'assets/icons/chevron-left.svg',
-                width: 24,
-                height: 24,
-              ),
-              onPressed: () {
-                Navigator.pop(context);
-              },
-            ),
-          ),
-        ),
+      appBar: CustomAppBar(
+        title: '커뮤니티',
         actions: [
           Padding(
             padding: const EdgeInsets.only(right: 15),
@@ -48,7 +31,7 @@ class _PostListPageState extends State<PostListPage> {
                 'assets/icons/search.svg',
                 width: 24,
                 height: 24,
-                color: AppColors.grey[700], 
+                color: AppColors.grey[700],
               ),
               onPressed: () {
                 Navigator.push(

--- a/lib/views/post/widgets/detail/post_detail_appbar.dart
+++ b/lib/views/post/widgets/detail/post_detail_appbar.dart
@@ -1,14 +1,27 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
-AppBar buildPostDetailAppBar(VoidCallback onMoreTap) {
-  return AppBar(
-    backgroundColor: Colors.white,
-    elevation: 0,
-    leading: const BackButton(color: Colors.black),
+CustomAppBar buildPostDetailAppBar(VoidCallback onMoreTap) {
+  return CustomAppBar(
+    title: '',
     actions: [
-      IconButton(
-        icon: const Icon(Icons.more_vert, color: Colors.black),
-        onPressed: onMoreTap,
+      GestureDetector(
+        onTap: onMoreTap,
+        child: Padding(
+          padding: const EdgeInsets.only(right: 12),
+          child: Container(
+            width: 44,
+            height: 44,
+            color: Colors.transparent,
+            child: SvgPicture.asset(
+              'assets/icons/more-vertical.svg',
+              width: 24,
+              height: 24,
+              fit: BoxFit.scaleDown,
+            ),
+          ),
+        ),
       ),
     ],
   );

--- a/lib/views/post/widgets/list/post_search_page.dart
+++ b/lib/views/post/widgets/list/post_search_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/views/post/widgets/list/post_list_view.dart';
 import 'package:travel_muse_app/views/post/widgets/list/post_search_bar.dart';
+import 'package:travel_muse_app/views/widgets/custom_app_bar.dart';
 
 class PostSearchPage extends StatefulWidget {
   const PostSearchPage({super.key});
@@ -15,7 +16,7 @@ class _PostSearchPageState extends State<PostSearchPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(),
+      appBar: CustomAppBar(title: ''),
       body: Column(
         children: [
           PostSearchBar(

--- a/lib/views/preference/preference_test_page.dart
+++ b/lib/views/preference/preference_test_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
-import 'package:travel_muse_app/core/widgets/svg_icon.dart';
+import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/viewmodels/preference/preference_test_view_model.dart';
 import 'package:travel_muse_app/views/preference/widgets/next_button.dart';
 import 'package:travel_muse_app/views/preference/widgets/page_indicator_bar.dart';
@@ -79,47 +81,53 @@ class _PreferenceTestPageState extends ConsumerState<PreferenceTestPage> {
       backgroundColor: AppColors.white,
       navigationBar: CupertinoNavigationBar(
         automaticallyImplyLeading: false,
-        backgroundColor: AppColors.primary[300],
+        backgroundColor: Colors.white,
         border: null,
-        leading: GestureDetector(
-          onTap: () {
-            if (_currentIndex > 0) {
-              setState(() {
-                _currentIndex--;
-                _selectedOption = null;
-              });
-            } else {
-              Navigator.pop(context);
-            }
-          },
-          child: Padding(
-            padding: const EdgeInsets.only(left: 16),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                SvgIcon.arrow(width: 27, height: 27),
-                const SizedBox(width: 8),
-                Text(
-                  '여행성향 테스트',
-                  style: TextStyle(
-                    color: AppColors.grey[800],
-                    fontSize: 18,
-                    fontWeight: FontWeight.w600,
+        leading: Padding(
+          padding: const EdgeInsets.only(left: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              GestureDetector(
+                onTap: () {
+                  if (_currentIndex > 0) {
+                    setState(() {
+                      _currentIndex--;
+                      _selectedOption = null;
+                    });
+                  } else {
+                    Navigator.pop(context);
+                  }
+                },
+                behavior: HitTestBehavior.opaque,
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 4.0),
+                  child: Container(
+                    width: 24,
+                    height: 44,
+                    color: Colors.transparent,
+                    child: Center(
+                      child: SvgPicture.asset(
+                        'assets/icons/chevron-left.svg',
+                        width: 24,
+                        height: 24,
+                        fit: BoxFit.scaleDown,
+                      ),
+                    ),
                   ),
                 ),
-              ],
-            ),
+              ),
+              SizedBox(width: 16),
+              Text('여행성향 테스트', style: AppTextStyles.appBarTitle),
+            ],
           ),
         ),
       ),
       child: SafeArea(
         child:
             isFinished
-                ? ResultView(
-                  onRestart: _restartTest,
-                  showButtons: true,
-                  testId: '',
-                )
+                ? ResultView(onRestart: _restartTest, showButtons: true, testId: '')
                 : Column(
                   children: [
                     Expanded(
@@ -137,10 +145,7 @@ class _PreferenceTestPageState extends ConsumerState<PreferenceTestPage> {
                       ),
                     ),
                     Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 8,
-                      ),
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                       child: NextButton(
                         onPressed: _onNextPressed,
                         enabled: _selectedOption != null,

--- a/lib/views/user/admin/admin_entry.dart
+++ b/lib/views/user/admin/admin_entry.dart
@@ -7,8 +7,6 @@ class AdminEntry extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const AdminGuard(
-      child: AdminPage(),
-    );
+    return const AdminGuard(child: AdminPage());
   }
 }

--- a/lib/views/widgets/custom_app_bar.dart
+++ b/lib/views/widgets/custom_app_bar.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:travel_muse_app/constants/app_text_styles.dart';
+
+class CustomAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const CustomAppBar({super.key, required this.title, this.actions});
+
+  final String title;
+  final List<Widget>? actions;
+
+  @override
+  Widget build(BuildContext context) {
+    final canGoBack = Navigator.of(context).canPop();
+
+    return AppBar(
+      elevation: 0,
+      backgroundColor: Colors.white,
+      automaticallyImplyLeading: false,
+      leading:
+          canGoBack
+              ? GestureDetector(
+                onTap: () => Navigator.of(context).maybePop(),
+                child: Container(
+                  width: 44,
+                  height: 44,
+                  color: Colors.transparent,
+                  child: SvgPicture.asset(
+                    'assets/icons/chevron-left.svg',
+                    width: 24,
+                    height: 24,
+                    fit: BoxFit.scaleDown,
+                  ),
+                ),
+              )
+              : null,
+      title: Text(title, style: AppTextStyles.appBarTitle),
+      centerTitle: false,
+      titleSpacing: 0,
+      actions: actions,
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/lib/views/widgets/edit_nickname.dart
+++ b/lib/views/widgets/edit_nickname.dart
@@ -35,6 +35,10 @@ class EditNickname extends ConsumerWidget {
                             .checkNicknameChanged(value);
                       },
                       textAlignVertical: TextAlignVertical.center,
+                      style: TextStyle(
+                        fontFamily: 'Pretendard',
+                        fontWeight: FontWeight.w700,
+                      ),
                       decoration: InputDecoration(
                         contentPadding: EdgeInsets.symmetric(
                           vertical: 16,
@@ -58,10 +62,7 @@ class EditNickname extends ConsumerWidget {
           SizedBox(
             child: Text(
               state.nicknameMessage ?? '',
-              style:
-                  showAsError
-                      ? AppTextStyles.errorText
-                      : AppTextStyles.helperText,
+              style: showAsError ? AppTextStyles.errorText : AppTextStyles.helperText,
             ),
           ),
         ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -796,10 +796,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -1321,10 +1321,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
### 🚀: 개요
- 텍스트폼필드 텍스트스타일 적용 및 전체 페이지 앱바 피그마 적용

### 🚀: 작업 내용
- EditNickname 위젯 내부 텍스트스타일 피그마 적용
- customAppBar위젯 생성 및 전체 페이지에 적용
- customAppBar위젯 적용 불가능한 페이지 앱바 ui customAppBar와 통일

### 📸: 실행 화면
<img src="https://github.com/user-attachments/assets/74547089-3126-41ac-8eac-5f32a3f5cefd" width="300" height="640"/>
<img src="https://github.com/user-attachments/assets/cc93a41f-208c-4687-afd4-0e21784658b2" width="300" height="640"/>

### 🚀: 조정 파일
- custom_app_bar.dart
- edit_nickname.dart
- 앱바 사용하는 모든 페이지 view 파일

### 개발 결과
- 앱바 스타일 통일 완료
- 텍스트폼필드 내부 텍스트에 텍스트스타일 적용 완료

### issue
Closes #255
