### PR TITLE
[Etc] 텍스트폼필드 내부 텍스트, 바텀바, 앱바 피그마 적용

### DIFF
--- a/assets/icons/more-vertical.svg
+++ b/assets/icons/more-vertical.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 13C12.5523 13 13 12.5523 13 12C13 11.4477 12.5523 11 12 11C11.4477 11 11 11.4477 11 12C11 12.5523 11.4477 13 12 13Z" stroke="#353A3C" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 6C12.5523 6 13 5.55228 13 5C13 4.44772 12.5523 4 12 4C11.4477 4 11 4.44772 11 5C11 5.55228 11.4477 6 12 6Z" stroke="#353A3C" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 20C12.5523 20 13 19.5523 13 19C13 18.4477 12.5523 18 12 18C11.4477 18 11 18.4477 11 19C11 19.5523 11.4477 20 12 20Z" stroke="#353A3C" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1716,15 +1716,15 @@ SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   BoringSSL-GRPC: dded2a44897e45f28f08ae87a55ee4bcd19bc508
-  cloud_firestore: 41c1ea0ea7b3f9b50a8fe27a59009b65b7ce7404
-  cloud_functions: 68d67463cf7985ad374b4e58113976de4836372f
+  cloud_firestore: 5c68298ed4398ab73ca3333ab99699add650ec1c
+  cloud_functions: 9c4252b4a2372f96feb0bf5368e1b850c47505ca
   Firebase: 3435bc66b4d494c2f22c79fd3aae4c1db6662327
-  firebase_analytics: 9bc12534b28e9955a6d02fac0478e92e027aed26
-  firebase_app_check: 94695458302cf6bb83b197c5b9afc09fd08181dd
-  firebase_auth: a9855fe79286576c5225b28aafed65bc374ac19a
-  firebase_core: a861be150c0e7c6aecedde077968eb92cbf790b9
-  firebase_crashlytics: aa26a226ac9a7047f729701fd8a60028a21f84ac
-  firebase_storage: 104d0dcc79a12fecc634a3cb725f7f174430cd58
+  firebase_analytics: 4af7b20cf0c2da4e0473117e01a69507db8d7c16
+  firebase_app_check: 9dd264a91837205c607bb2abc6bb3e71b5071bb7
+  firebase_auth: ebc1f561cc3077efebad5005974c9ed58008973b
+  firebase_core: 700bac7ed92bb754fd70fbf01d72b36ecdd6d450
+  firebase_crashlytics: d101fbdc2dba187f483f13ae3ce9281779d664db
+  firebase_storage: 54cc3c866fe4cb619bacb774bb946014e7609625
   FirebaseAnalytics: 630349facf4a114a0977e5d7570e104261973287
   FirebaseAppCheck: 6097c3bdf50028493a86b28297d0f1f3309c0741
   FirebaseAppCheckInterop: a92ba81d0ee3c4cddb1a2e52c668ea51dc63c3ae
@@ -1744,13 +1744,13 @@ SPEC CHECKSUMS:
   FirebaseSharedSwift: bdd5c8674c4712a98e70287c936bc5cca5d640f6
   FirebaseStorage: 2a3e5402a565e06e121308dadfe0626976fd6b45
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
-  flutter_local_notifications: ff50f8405aaa0ccdc7dcfb9022ca192e8ad9688f
-  fluttertoast: 21eecd6935e7064cc1fcb733a4c5a428f3f24f0f
-  geolocator_apple: 66b711889fd333205763b83c9dcf0a57a28c7afd
+  flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
+  flutter_local_notifications: a5a732f069baa862e728d839dd2ebb904737effb
+  fluttertoast: 2c67e14dce98bbdb200df9e1acf610d7a6264ea1
+  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
-  google_maps_flutter_ios: e31555a04d1986ab130f2b9f24b6cdc861acc6d3
-  google_sign_in_ios: 7411fab6948df90490dc4620ecbcabdc3ca04017
+  google_maps_flutter_ios: 0291eb2aa252298a769b04d075e4a9d747ff7264
+  google_sign_in_ios: b48bb9af78576358a168361173155596c845f0b9
   GoogleAppMeasurement: 0dfca1a4b534d123de3945e28f77869d10d0d600
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
@@ -1760,22 +1760,22 @@ SPEC CHECKSUMS:
   gRPC-Core: 860978b7db482de8b4f5e10677216309b5ff6330
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
+  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sign_in_with_apple: f3bf75217ea4c2c8b91823f225d70230119b8440
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  webview_flutter_wkwebview: a4af96a051138e28e29f60101d094683b9f82188
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
 
 PODFILE CHECKSUM: 07ebf3f572f507bd575af81066430d274ad6951f
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_easyloading/flutter_easyloading.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/firebase_options.dart';
 import 'package:travel_muse_app/utills/notification_helper.dart';
 import 'package:travel_muse_app/views/user/splash/splash_page.dart';
@@ -41,7 +42,13 @@ class MyApp extends StatelessWidget {
       builder: EasyLoading.init(),
       theme: ThemeData(
         scaffoldBackgroundColor: Colors.white,
-        appBarTheme: const AppBarTheme(backgroundColor: Colors.white),
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Colors.white,
+          elevation: 0,
+          centerTitle: false,
+          titleSpacing: 0,
+          titleTextStyle: AppTextStyles.appBarTitle,
+        ),
       ),
       home: const SplashPage(),
     );

--- a/lib/views/home/recommended_place/recommended_place_detail_page.dart
+++ b/lib/views/home/recommended_place/recommended_place_detail_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/models/home/home_place.dart';
@@ -33,50 +34,48 @@ class _RecommendedPlaceDetailPageState extends ConsumerState<RecommendedPlaceDet
     return Scaffold(
       backgroundColor: AppColors.white,
       appBar: AppBar(
-        backgroundColor: AppColors.white,
-        elevation: 0,
         automaticallyImplyLeading: false,
-        titleSpacing: 0,
-        title: Row(
-          children: [
-            IconButton(
-              icon: Icon(Icons.chevron_left, color: AppColors.grey[500], size: 24),
-              onPressed:
-                  () => Navigator.pop(context, {
-                    'title': place.title,
-                    'lat': place.latLng.latitude,
-                    'lng': place.latLng.longitude,
-                    'address': place.address,
-                  }),
+        title: Text(place.title, style: AppTextStyles.appBarTitle),
+        centerTitle: true,
+        leading: GestureDetector(
+          onTap:
+              () => Navigator.pop(context, {
+                'title': place.title,
+                'lat': place.latLng.latitude,
+                'lng': place.latLng.longitude,
+                'address': place.address,
+              }),
+
+          child: Container(
+            padding: EdgeInsets.only(top: 4),
+            width: 44,
+            height: 44,
+            color: Colors.amber,
+            child: SvgPicture.asset(
+              'assets/icons/chevron-left.svg',
+              width: 24,
+              height: 24,
+              fit: BoxFit.scaleDown,
             ),
-            Spacer(),
-            Text(
-              place.title,
-              style: const TextStyle(
-                fontSize: 18,
-                fontWeight: FontWeight.w700,
-                color: AppColors.black,
-                fontFamily: 'Pretendard',
-              ),
-            ),
-            Spacer(),
-            IconButton(
-              iconSize: 24,
-              icon: Icon(
-                isScrapped ? Icons.bookmark : Icons.bookmark_border,
-                color: isScrapped ? AppColors.primary[300] : AppColors.black,
-              ),
-              onPressed: () {
-                ref.read(scrapViewModelProvider.notifier).toggleScrap(place);
-                CustomToast.show(
-                  context: context,
-                  message: '북마크에 저장했습니다.',
-                  duration: const Duration(seconds: 2),
-                );
-              },
-            ),
-          ],
+          ),
         ),
+        actions: [
+          IconButton(
+            iconSize: 24,
+            icon: Icon(
+              isScrapped ? Icons.bookmark : Icons.bookmark_border,
+              color: isScrapped ? AppColors.primary[300] : AppColors.black,
+            ),
+            onPressed: () {
+              ref.read(scrapViewModelProvider.notifier).toggleScrap(place);
+              CustomToast.show(
+                context: context,
+                message: '북마크에 저장했습니다.',
+                duration: const Duration(seconds: 2),
+              );
+            },
+          ),
+        ],
       ),
       // floatingActionButton: FloatingActionButton.extended(
       //   backgroundColor: AppColors.primary[50],

--- a/lib/views/home/recommended_place/recommended_place_detail_page.dart
+++ b/lib/views/home/recommended_place/recommended_place_detail_page.dart
@@ -22,14 +22,17 @@ class RecommendedPlaceDetailPage extends ConsumerStatefulWidget {
       _RecommendedPlaceDetailPageState();
 }
 
-class _RecommendedPlaceDetailPageState extends ConsumerState<RecommendedPlaceDetailPage> {
+class _RecommendedPlaceDetailPageState
+    extends ConsumerState<RecommendedPlaceDetailPage> {
   int _currentPage = 0;
   final PageController _pageController = PageController();
 
   @override
   Widget build(BuildContext context) {
     final place = widget.place;
-    final isScrapped = ref.watch(scrapViewModelProvider).contains(place.id);
+    final isScrapped = ref
+        .watch(scrapViewModelProvider)
+        .contains(place.id);
 
     return Scaffold(
       backgroundColor: AppColors.white,
@@ -50,7 +53,7 @@ class _RecommendedPlaceDetailPageState extends ConsumerState<RecommendedPlaceDet
             padding: EdgeInsets.only(top: 4),
             width: 44,
             height: 44,
-            color: Colors.amber,
+            color: Colors.transparent,
             child: SvgPicture.asset(
               'assets/icons/chevron-left.svg',
               width: 24,
@@ -64,10 +67,15 @@ class _RecommendedPlaceDetailPageState extends ConsumerState<RecommendedPlaceDet
             iconSize: 24,
             icon: Icon(
               isScrapped ? Icons.bookmark : Icons.bookmark_border,
-              color: isScrapped ? AppColors.primary[300] : AppColors.black,
+              color:
+                  isScrapped
+                      ? AppColors.primary[300]
+                      : AppColors.black,
             ),
             onPressed: () {
-              ref.read(scrapViewModelProvider.notifier).toggleScrap(place);
+              ref
+                  .read(scrapViewModelProvider.notifier)
+                  .toggleScrap(place);
               CustomToast.show(
                 context: context,
                 message: '북마크에 저장했습니다.',
@@ -101,7 +109,8 @@ class _RecommendedPlaceDetailPageState extends ConsumerState<RecommendedPlaceDet
               imageUrls: [place.thumbnail],
               currentPage: _currentPage,
               pageController: _pageController,
-              onPageChanged: (index) => setState(() => _currentPage = index),
+              onPageChanged:
+                  (index) => setState(() => _currentPage = index),
             ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),

--- a/lib/views/home/recommended_place/recommended_place_detail_page.dart
+++ b/lib/views/home/recommended_place/recommended_place_detail_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/models/home/home_place.dart';
 import 'package:travel_muse_app/providers/home/scrap_provider.dart';
@@ -20,8 +21,7 @@ class RecommendedPlaceDetailPage extends ConsumerStatefulWidget {
       _RecommendedPlaceDetailPageState();
 }
 
-class _RecommendedPlaceDetailPageState
-    extends ConsumerState<RecommendedPlaceDetailPage> {
+class _RecommendedPlaceDetailPageState extends ConsumerState<RecommendedPlaceDetailPage> {
   int _currentPage = 0;
   final PageController _pageController = PageController();
 
@@ -40,11 +40,7 @@ class _RecommendedPlaceDetailPageState
         title: Row(
           children: [
             IconButton(
-              icon: Icon(
-                Icons.chevron_left,
-                color: AppColors.grey[500],
-                size: 24,
-              ),
+              icon: Icon(Icons.chevron_left, color: AppColors.grey[500], size: 24),
               onPressed:
                   () => Navigator.pop(context, {
                     'title': place.title,
@@ -160,6 +156,7 @@ class _RecommendedPlaceDetailPageState
           ],
         ),
       ),
+      bottomNavigationBar: const BottomBar(),
     );
   }
 }

--- a/lib/views/home/recommended_place/recommended_places_list_page.dart
+++ b/lib/views/home/recommended_place/recommended_places_list_page.dart
@@ -18,9 +18,6 @@ class RecommendedPlacesListPage extends ConsumerWidget {
       appBar: AppBar(
         title: const Text('추천 명소'),
         leading: Navigator.canPop(context) ? const CustomBackButton() : null,
-        backgroundColor: AppColors.white,
-        elevation: 1,
-        iconTheme: const IconThemeData(color: AppColors.black),
       ),
       body: SafeArea(
         child: homeAsync.when(

--- a/lib/views/home/recommended_place/recommended_places_list_page.dart
+++ b/lib/views/home/recommended_place/recommended_places_list_page.dart
@@ -4,6 +4,7 @@ import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/providers/home/home_view_model_provider.dart';
 import 'package:travel_muse_app/views/home/recommended_place/widgets/recommended_place_list_card.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class RecommendedPlacesListPage extends ConsumerWidget {
   const RecommendedPlacesListPage({super.key});
@@ -15,15 +16,8 @@ class RecommendedPlacesListPage extends ConsumerWidget {
     return Scaffold(
       backgroundColor: AppColors.white,
       appBar: AppBar(
-        title: const Text(
-          '추천 명소',
-          style: TextStyle(
-            color: AppColors.black,
-            fontSize: 18,
-            fontWeight: FontWeight.w700,
-            fontFamily: 'Pretendard',
-          ),
-        ),
+        title: const Text('추천 명소'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
         backgroundColor: AppColors.white,
         elevation: 1,
         iconTheme: const IconThemeData(color: AppColors.black),
@@ -53,7 +47,7 @@ class RecommendedPlacesListPage extends ConsumerWidget {
                       isActive: true,
                       place: spot,
                     ),
-                Divider(height: 1, thickness: 0.5, color: AppColors.grey[200]),
+                    Divider(height: 1, thickness: 0.5, color: AppColors.grey[200]),
                   ],
                 );
               },

--- a/lib/views/my_page/edit_profile_page.dart
+++ b/lib/views/my_page/edit_profile_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/providers/user/profile_view_model_provider.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 import 'package:travel_muse_app/views/widgets/edit_nickname.dart';
 import 'package:travel_muse_app/views/widgets/edit_profile_image.dart';
 import 'package:travel_muse_app/views/widgets/user_next_button.dart';
@@ -15,11 +16,8 @@ class EditProfilePage extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text(
-          '프로필 수정',
-          style: TextStyle(fontWeight: FontWeight.bold),
-        ),
-        centerTitle: false,
+        title: const Text('프로필 수정'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
       ),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 20),

--- a/lib/views/my_page/like_list_page.dart
+++ b/lib/views/my_page/like_list_page.dart
@@ -2,12 +2,12 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
-import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/models/post/post_model.dart';
 import 'package:travel_muse_app/providers/post/like_provider.dart';
 import 'package:travel_muse_app/views/post/post_detail_page.dart';
 import 'package:travel_muse_app/views/post/widgets/list/post_item.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class LikeListPage extends ConsumerStatefulWidget {
   const LikeListPage({super.key});
@@ -37,8 +37,8 @@ class _LikeListPageState extends ConsumerState<LikeListPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('좋아요한 게시글', style: AppTextStyles.appBarTitle),
-        centerTitle: false,
+        title: const Text('좋아요한 게시글'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
       ),
       body: FutureBuilder<List<Post>>(
         future: likeRepository.fetchLikedPosts(userId!),
@@ -52,9 +52,7 @@ class _LikeListPageState extends ConsumerState<LikeListPage> {
           }
 
           final posts =
-              (snapshot.data ?? [])
-                  .where((post) => post.isDeleted == false)
-                  .toList();
+              (snapshot.data ?? []).where((post) => post.isDeleted == false).toList();
 
           if (posts.isEmpty) {
             return const Center(child: Text('좋아요한 게시글이 없습니다.'));
@@ -72,9 +70,7 @@ class _LikeListPageState extends ConsumerState<LikeListPage> {
                 onTap: () async {
                   final result = await Navigator.push(
                     context,
-                    MaterialPageRoute(
-                      builder: (_) => PostDetailPage(post: post),
-                    ),
+                    MaterialPageRoute(builder: (_) => PostDetailPage(post: post)),
                   );
 
                   if (mounted) setState(() {}); // 좋아요 취소 시 목록 갱신
@@ -85,10 +81,7 @@ class _LikeListPageState extends ConsumerState<LikeListPage> {
                   decoration: ShapeDecoration(
                     color: AppColors.white,
                     shape: RoundedRectangleBorder(
-                      side: BorderSide(
-                        width: 0.20,
-                        color: AppColors.grey[200]!,
-                      ),
+                      side: BorderSide(width: 0.20, color: AppColors.grey[200]!),
                     ),
                   ),
                   child: PostItem(screenWidth: screenWidth, post: post),

--- a/lib/views/my_page/my_page.dart
+++ b/lib/views/my_page/my_page.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
-import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/views/my_page/widgets/my_page_menu.dart';
 import 'package:travel_muse_app/views/my_page/widgets/my_profile_screen.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class MyPage extends StatelessWidget {
   const MyPage({super.key});
@@ -13,8 +13,8 @@ class MyPage extends StatelessWidget {
     return Scaffold(
       backgroundColor: AppColors.white,
       appBar: AppBar(
-        title: Text('마이페이지', style: AppTextStyles.appBarTitle),
-        centerTitle: false,
+        title: Text('마이페이지'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
       ),
       body: SafeArea(
         child: SingleChildScrollView(

--- a/lib/views/my_page/my_post_page.dart
+++ b/lib/views/my_page/my_post_page.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
-import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/providers/post/my_posts_view_model_provider.dart';
 import 'package:travel_muse_app/views/post/post_detail_page.dart';
 import 'package:travel_muse_app/views/post/widgets/list/post_item.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class MyPostPage extends ConsumerWidget {
   const MyPostPage({super.key});
@@ -17,13 +17,12 @@ class MyPostPage extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text('내 게시물', style: AppTextStyles.appBarTitle),
-        centerTitle: false,
+        title: Text('내 게시물'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
       ),
       body: postAsync.when(
         data: (data) {
-          final filtered =
-              data.where((post) => post.isDeleted == false).toList();
+          final filtered = data.where((post) => post.isDeleted == false).toList();
 
           if (filtered.isEmpty) {
             return const Center(child: Text('작성한 게시물이 없습니다.'));
@@ -36,9 +35,7 @@ class MyPostPage extends ConsumerWidget {
                 onTap: () {
                   Navigator.push(
                     context,
-                    MaterialPageRoute(
-                      builder: (context) => PostDetailPage(post: post),
-                    ),
+                    MaterialPageRoute(builder: (context) => PostDetailPage(post: post)),
                   );
                 },
                 child: Container(
@@ -47,10 +44,7 @@ class MyPostPage extends ConsumerWidget {
                   decoration: ShapeDecoration(
                     color: AppColors.white,
                     shape: RoundedRectangleBorder(
-                      side: BorderSide(
-                        width: 0.20,
-                        color: AppColors.grey[200]!,
-                      ),
+                      side: BorderSide(width: 0.20, color: AppColors.grey[200]!),
                     ),
                   ),
                   child: PostItem(screenWidth: screenWidth, post: post),

--- a/lib/views/my_page/my_scrap_list_page.dart
+++ b/lib/views/my_page/my_scrap_list_page.dart
@@ -6,6 +6,7 @@ import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/providers/home/scrap_provider.dart';
 import 'package:travel_muse_app/views/home/recommended_place/recommended_place_detail_page.dart';
 import 'package:travel_muse_app/views/my_page/widgets/confirm_dialog.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class MyScrapListPage extends ConsumerWidget {
   const MyScrapListPage({super.key});
@@ -16,7 +17,10 @@ class MyScrapListPage extends ConsumerWidget {
     final state = ref.watch(scrapListViewModelProvider);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('북마크'), centerTitle: false, elevation: 0),
+      appBar: AppBar(
+        title: const Text('북마크'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
+      ),
       body: state.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (err, _) => Center(child: Text('에러 발생: $err')),

--- a/lib/views/my_page/my_scrap_list_page.dart
+++ b/lib/views/my_page/my_scrap_list_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/providers/home/scrap_provider.dart';
 import 'package:travel_muse_app/views/home/recommended_place/recommended_place_detail_page.dart';
@@ -15,11 +16,7 @@ class MyScrapListPage extends ConsumerWidget {
     final state = ref.watch(scrapListViewModelProvider);
 
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('북마크'),
-        centerTitle: false,
-        elevation: 0,
-      ),
+      appBar: AppBar(title: const Text('북마크'), centerTitle: false, elevation: 0),
       body: state.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (err, _) => Center(child: Text('에러 발생: $err')),
@@ -134,6 +131,7 @@ class MyScrapListPage extends ConsumerWidget {
           );
         },
       ),
+      bottomNavigationBar: const BottomBar(),
     );
   }
 }

--- a/lib/views/my_page/plan_list_page.dart
+++ b/lib/views/my_page/plan_list_page.dart
@@ -2,7 +2,6 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
-import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/providers/plan/schedule/schedule_provider.dart';
@@ -13,6 +12,7 @@ import 'package:travel_muse_app/viewmodels/plan/schedule_view_model.dart';
 import 'package:travel_muse_app/views/my_page/widgets/confirm_dialog.dart';
 import 'package:travel_muse_app/views/my_page/widgets/my_page_list_item.dart';
 import 'package:travel_muse_app/views/plan/plan/schedule/schedule_page.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class PlanListPage extends ConsumerStatefulWidget {
   const PlanListPage({super.key});
@@ -67,8 +67,8 @@ class _PlanListPageState extends ConsumerState<PlanListPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text('나의 여행', style: AppTextStyles.appBarTitle),
-        centerTitle: false,
+        title: const Text('나의 여행'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
       ),
       body: SafeArea(
         child:

--- a/lib/views/my_page/preference_list_page.dart
+++ b/lib/views/my_page/preference_list_page.dart
@@ -7,6 +7,7 @@ import 'package:travel_muse_app/providers/preference/preference_test_provider.da
 import 'package:travel_muse_app/providers/user/profile_view_model_provider.dart';
 import 'package:travel_muse_app/views/my_page/widgets/my_page_list_item.dart';
 import 'package:travel_muse_app/views/preference/widgets/result_view.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class PreferenceListPage extends ConsumerStatefulWidget {
   const PreferenceListPage({super.key});
@@ -36,10 +37,8 @@ class _PreferenceListPageState extends ConsumerState<PreferenceListPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text(
-          '나의 성향',
-          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-        ),
+        title: const Text('나의 여행 성향'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
       ),
       body: SafeArea(
         child: Padding(
@@ -69,10 +68,7 @@ class _PreferenceListPageState extends ConsumerState<PreferenceListPage> {
                           if (result == 'deleted') {
                             final tests =
                                 await ref
-                                    .read(
-                                      preferenceTestStateNotifierProvider
-                                          .notifier,
-                                    )
+                                    .read(preferenceTestStateNotifierProvider.notifier)
                                     .fetchTestsByUserId();
                             setState(() {
                               _tests = tests;

--- a/lib/views/my_page/settings/account_setting_page.dart
+++ b/lib/views/my_page/settings/account_setting_page.dart
@@ -7,6 +7,7 @@ import 'package:travel_muse_app/views/my_page/widgets/account_info.dart';
 import 'package:travel_muse_app/views/my_page/widgets/confirm_dialog.dart';
 import 'package:travel_muse_app/views/my_page/widgets/my_profile_screen.dart';
 import 'package:travel_muse_app/views/user/login/login_page.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class AccountSettingPage extends ConsumerStatefulWidget {
   const AccountSettingPage({super.key});
@@ -20,17 +21,8 @@ class _AccountSettingPageState extends ConsumerState<AccountSettingPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text(
-          '계정 관리',
-          style: TextStyle(
-            color: Colors.black,
-            fontFamily: 'Pretendard',
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        backgroundColor: Colors.white,
-        elevation: 0,
-        iconTheme: const IconThemeData(color: Colors.black),
+        title: const Text('계정 관리'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
       ),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/views/my_page/settings/environment_setting_page.dart
+++ b/lib/views/my_page/settings/environment_setting_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 
 class EnvironmentSettingPage extends StatelessWidget {
   const EnvironmentSettingPage({super.key});
@@ -37,9 +38,7 @@ class EnvironmentSettingPage extends StatelessWidget {
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
               decoration: BoxDecoration(
-                border: Border(
-                  bottom: BorderSide(width: 1, color: AppColors.grey[50]!),
-                ),
+                border: Border(bottom: BorderSide(width: 1, color: AppColors.grey[50]!)),
               ),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -59,17 +58,14 @@ class EnvironmentSettingPage extends StatelessWidget {
                       ),
                     ),
                   ),
-                  Icon(
-                    Icons.arrow_forward_ios,
-                    size: 16,
-                    color: AppColors.grey[600],
-                  ),
+                  Icon(Icons.arrow_forward_ios, size: 16, color: AppColors.grey[600]),
                 ],
               ),
             ),
           );
         },
       ),
+      bottomNavigationBar: const BottomBar(),
     );
   }
 }

--- a/lib/views/my_page/settings/environment_setting_page.dart
+++ b/lib/views/my_page/settings/environment_setting_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class EnvironmentSettingPage extends StatelessWidget {
   const EnvironmentSettingPage({super.key});
@@ -18,17 +19,8 @@ class EnvironmentSettingPage extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text(
-          '서비스 약관',
-          style: TextStyle(
-            color: Colors.black,
-            fontFamily: 'Pretendard',
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        backgroundColor: Colors.white,
-        elevation: 0,
-        iconTheme: const IconThemeData(color: Colors.black),
+        title: const Text('환경 설정'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
       ),
       body: ListView.builder(
         itemCount: settingsItems.length,

--- a/lib/views/my_page/settings/notification_setting_page.dart
+++ b/lib/views/my_page/settings/notification_setting_page.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/utills/notification_helper.dart';
-import 'package:travel_muse_app/utills/notification_setting.dart'; // SharedPreferences 저장소
+import 'package:travel_muse_app/utills/notification_setting.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart'; // SharedPreferences 저장소
 
 class NotificationSettingPage extends StatefulWidget {
   const NotificationSettingPage({super.key});
@@ -107,17 +108,8 @@ class _NotificationSettingPageState extends State<NotificationSettingPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text(
-          '알림 설정',
-          style: TextStyle(
-            color: Colors.black,
-            fontFamily: 'Pretendard',
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        backgroundColor: Colors.white,
-        elevation: 0,
-        iconTheme: const IconThemeData(color: Colors.black),
+        title: const Text('알림 설정'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
       ),
       body:
           _switchValues.length < settingsItems.length

--- a/lib/views/my_page/settings/notification_setting_page.dart
+++ b/lib/views/my_page/settings/notification_setting_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/utills/notification_helper.dart';
 import 'package:travel_muse_app/utills/notification_setting.dart'; // SharedPreferences 저장소
 
@@ -7,8 +8,7 @@ class NotificationSettingPage extends StatefulWidget {
   const NotificationSettingPage({super.key});
 
   @override
-  State<NotificationSettingPage> createState() =>
-      _NotificationSettingPageState();
+  State<NotificationSettingPage> createState() => _NotificationSettingPageState();
 }
 
 class _NotificationSettingPageState extends State<NotificationSettingPage> {
@@ -128,16 +128,10 @@ class _NotificationSettingPageState extends State<NotificationSettingPage> {
                   final item = settingsItems[index];
                   final value = _switchValues[item] ?? true;
                   return Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 16,
-                      vertical: 16,
-                    ),
+                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
                     decoration: BoxDecoration(
                       border: Border(
-                        bottom: BorderSide(
-                          width: 1,
-                          color: AppColors.grey[50]!,
-                        ),
+                        bottom: BorderSide(width: 1, color: AppColors.grey[50]!),
                       ),
                     ),
                     child: Row(
@@ -168,6 +162,7 @@ class _NotificationSettingPageState extends State<NotificationSettingPage> {
                   );
                 },
               ),
+      bottomNavigationBar: const BottomBar(),
     );
   }
 }

--- a/lib/views/my_page/settings/service_term_page.dart
+++ b/lib/views/my_page/settings/service_term_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/views/user/onboarding/terms_web_view_page.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 final List<Map<String, String>> termsData = [
   {'title': '만 14세 이상입니다.', 'url': ''},
@@ -22,17 +23,8 @@ class ServiceTermPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text(
-          '서비스 약관',
-          style: TextStyle(
-            color: Colors.black,
-            fontFamily: 'Pretendard',
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        backgroundColor: Colors.white,
-        elevation: 0,
-        iconTheme: const IconThemeData(color: Colors.black),
+        title: const Text('서비스 약관', style: TextStyle()),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
       ),
       body: ListView.builder(
         itemCount: termsData.length,

--- a/lib/views/my_page/settings/service_term_page.dart
+++ b/lib/views/my_page/settings/service_term_page.dart
@@ -1,29 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/views/user/onboarding/terms_web_view_page.dart';
 
 final List<Map<String, String>> termsData = [
   {'title': '만 14세 이상입니다.', 'url': ''},
-  {
-    'title': '서비스 이용약관',
-    'url': 'https://www.notion.so/21cc9d67bce980ab9579ebf380ad5d2c',
-  },
-  {
-    'title': '개인정보 처리방침',
-    'url': 'https://www.notion.so/21cc9d67bce980d58f34ec20ee46d139',
-  },
+  {'title': '서비스 이용약관', 'url': 'https://www.notion.so/21cc9d67bce980ab9579ebf380ad5d2c'},
+  {'title': '개인정보 처리방침', 'url': 'https://www.notion.so/21cc9d67bce980d58f34ec20ee46d139'},
   {
     'title': '마케팅 수신 동의',
     'url': 'https://www.notion.so/21cc9d67bce980ab9579ebf380ad5d2c?pvs=12',
   },
-  {
-    'title': '커뮤니티 운영정책',
-    'url': 'https://www.notion.so/21cc9d67bce980b1a257c3a7dcf39cc2',
-  },
-  {
-    'title': '위치정보 이용동의',
-    'url': 'https://www.notion.so/21cc9d67bce9802e92f5fbaceffe6190',
-  },
+  {'title': '커뮤니티 운영정책', 'url': 'https://www.notion.so/21cc9d67bce980b1a257c3a7dcf39cc2'},
+  {'title': '위치정보 이용동의', 'url': 'https://www.notion.so/21cc9d67bce9802e92f5fbaceffe6190'},
 ];
 
 class ServiceTermPage extends StatelessWidget {
@@ -68,9 +57,7 @@ class ServiceTermPage extends StatelessWidget {
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
               decoration: BoxDecoration(
-                border: Border(
-                  bottom: BorderSide(width: 1, color: AppColors.grey[50]!),
-                ),
+                border: Border(bottom: BorderSide(width: 1, color: AppColors.grey[50]!)),
               ),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -103,6 +90,7 @@ class ServiceTermPage extends StatelessWidget {
           );
         },
       ),
+      bottomNavigationBar: const BottomBar(),
     );
   }
 }

--- a/lib/views/my_page/settings/setting_page.dart
+++ b/lib/views/my_page/settings/setting_page.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/views/my_page/settings/account_setting_page.dart';
 import 'package:travel_muse_app/views/my_page/settings/environment_setting_page.dart';
 import 'package:travel_muse_app/views/my_page/settings/notification_setting_page.dart';
@@ -51,10 +52,8 @@ class _SettingPageState extends State<SettingPage> {
       {'title': '서비스 약관', 'route': const ServiceTermPage()},
       {'title': '고객 지원', 'route': const SupportPage()},
       {'title': '버전 정보', 'route': const VersionPage()},
-      if (_isAdmin)
-        {'title': '운영자 권한 설정', 'route': const AdminEntry()},
-      if (_isAdmin)
-        {'title': '신고 컨텐츠 관리', 'route': const AdminReportEntry()},
+      if (_isAdmin) {'title': '운영자 권한 설정', 'route': const AdminEntry()},
+      if (_isAdmin) {'title': '신고 컨텐츠 관리', 'route': const AdminReportEntry()},
     ];
 
     return Scaffold(
@@ -78,17 +77,13 @@ class _SettingPageState extends State<SettingPage> {
             onTap: () {
               Navigator.push(
                 context,
-                MaterialPageRoute(
-                  builder: (_) => settingsItems[index]['route'],
-                ),
+                MaterialPageRoute(builder: (_) => settingsItems[index]['route']),
               );
             },
             child: Container(
               padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
               decoration: BoxDecoration(
-                border: Border(
-                  bottom: BorderSide(width: 1, color: AppColors.grey[50]!),
-                ),
+                border: Border(bottom: BorderSide(width: 1, color: AppColors.grey[50]!)),
               ),
               child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -108,17 +103,14 @@ class _SettingPageState extends State<SettingPage> {
                       ),
                     ),
                   ),
-                  Icon(
-                    Icons.arrow_forward_ios,
-                    size: 16,
-                    color: AppColors.grey[600],
-                  ),
+                  Icon(Icons.arrow_forward_ios, size: 16, color: AppColors.grey[600]),
                 ],
               ),
             ),
           );
         },
       ),
+      bottomNavigationBar: const BottomBar(),
     );
   }
 }

--- a/lib/views/my_page/settings/setting_page.dart
+++ b/lib/views/my_page/settings/setting_page.dart
@@ -10,6 +10,7 @@ import 'package:travel_muse_app/views/my_page/settings/support_page.dart';
 import 'package:travel_muse_app/views/my_page/settings/version_page.dart';
 import 'package:travel_muse_app/views/user/admin/admin_entry.dart';
 import 'package:travel_muse_app/views/user/admin/admin_report_entry.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class SettingPage extends StatefulWidget {
   const SettingPage({super.key});
@@ -58,17 +59,8 @@ class _SettingPageState extends State<SettingPage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text(
-          '설정',
-          style: TextStyle(
-            color: Colors.black,
-            fontFamily: 'Pretendard',
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        backgroundColor: Colors.white,
-        elevation: 0,
-        iconTheme: const IconThemeData(color: Colors.black),
+        title: const Text('설정'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
       ),
       body: ListView.builder(
         itemCount: settingsItems.length,

--- a/lib/views/my_page/settings/support_page.dart
+++ b/lib/views/my_page/settings/support_page.dart
@@ -1,10 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class SupportPage extends StatelessWidget {
   const SupportPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(appBar: AppBar(title: Text('고객 지원')), body: Text('고객 지원'));
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('고객 지원'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
+      ),
+      body: Text('고객 지원'),
+    );
   }
 }

--- a/lib/views/my_page/settings/version_page.dart
+++ b/lib/views/my_page/settings/version_page.dart
@@ -1,10 +1,17 @@
 import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class VersionPage extends StatelessWidget {
   const VersionPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(appBar: AppBar(title: Text('버전 정보')), body: Text('버전 정보'));
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('버전 정보'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
+      ),
+      body: Text('버전 정보'),
+    );
   }
 }

--- a/lib/views/plan/location/map_page.dart
+++ b/lib/views/plan/location/map_page.dart
@@ -7,8 +7,8 @@ import 'package:travel_muse_app/utills/map_utils.dart';
 import 'package:travel_muse_app/viewmodels/plan/map_view_model.dart';
 import 'package:travel_muse_app/views/plan/location/widgets/day_tab_bar.dart';
 import 'package:travel_muse_app/views/plan/location/widgets/map_display.dart';
-import 'package:travel_muse_app/views/plan/location/widgets/map_page_app_bar.dart';
 import 'package:travel_muse_app/views/plan/location/widgets/place_carousel.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class MapPage extends ConsumerStatefulWidget {
   const MapPage({super.key, required this.planId});
@@ -17,8 +17,7 @@ class MapPage extends ConsumerStatefulWidget {
   ConsumerState<MapPage> createState() => _MapPageState();
 }
 
-class _MapPageState extends ConsumerState<MapPage>
-    with TickerProviderStateMixin {
+class _MapPageState extends ConsumerState<MapPage> with TickerProviderStateMixin {
   GoogleMapController? _mapController;
   bool _cameraMoved = false;
   LatLng _initialLatLng = const LatLng(33.4996, 126.5312);
@@ -36,8 +35,7 @@ class _MapPageState extends ConsumerState<MapPage>
         final allPlaces = _viewModel.getAllPlaces();
         _viewModel.moveCameraToFitAll(_mapController, allPlaces);
       } else {
-        final newPlaces =
-            mapState.dayPlaces[dayKeys[_tabController!.index - 1]] ?? [];
+        final newPlaces = mapState.dayPlaces[dayKeys[_tabController!.index - 1]] ?? [];
         _viewModel.moveCameraToFitAll(_mapController, newPlaces);
       }
     }
@@ -118,7 +116,10 @@ class _MapPageState extends ConsumerState<MapPage>
     );
     final displayDayTabs = ['All', ...dayKeys.map(getDisplayDayTab)];
     return Scaffold(
-      appBar: MapPageAppBar(),
+      appBar: AppBar(
+        title: const Text('지도'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
+      ),
       body: Column(
         children: [
           Expanded(
@@ -130,10 +131,7 @@ class _MapPageState extends ConsumerState<MapPage>
                 _mapController = controller;
                 if (!_cameraMoved && selectedPlaces.isNotEmpty) {
                   Future.delayed(const Duration(milliseconds: 300), () {
-                    _viewModel.moveCameraToFitAll(
-                      _mapController,
-                      selectedPlaces,
-                    );
+                    _viewModel.moveCameraToFitAll(_mapController, selectedPlaces);
                     _cameraMoved = true;
                   });
                 }

--- a/lib/views/plan/plan/calendar/calendar_page.dart
+++ b/lib/views/plan/plan/calendar/calendar_page.dart
@@ -6,6 +6,7 @@ import 'package:travel_muse_app/utills/date_utils.dart';
 import 'package:travel_muse_app/views/plan/plan/calendar/widgets/calendar_guide_text.dart';
 import 'package:travel_muse_app/views/plan/plan/calendar/widgets/calendar_widget.dart';
 import 'package:travel_muse_app/views/plan/plan/location_setting/province_setting_page.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class CalendarPage extends ConsumerWidget {
   const CalendarPage({super.key});
@@ -17,13 +18,8 @@ class CalendarPage extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
-        title: const Text(
-          '여행 일정 등록',
-          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18),
-        ),
-        backgroundColor: Colors.white,
-        foregroundColor: Colors.grey[800],
-        elevation: 0,
+        title: const Text('여행 일정 등록'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
       ),
       body: SafeArea(
         child: Padding(
@@ -40,8 +36,7 @@ class CalendarPage extends ConsumerWidget {
                     final year =
                         state.focusedDay.year +
                         ((state.focusedDay.month + index - 1) ~/ 12);
-                    final month =
-                        ((state.focusedDay.month + index - 1) % 12) + 1;
+                    final month = ((state.focusedDay.month + index - 1) % 12) + 1;
 
                     final focusedMonth = DateTime(year, month);
 
@@ -68,9 +63,7 @@ class CalendarPage extends ConsumerWidget {
                     ),
                   ),
                   onPressed: () {
-                    final viewModel = ref.read(
-                      calendarViewModelProvider.notifier,
-                    );
+                    final viewModel = ref.read(calendarViewModelProvider.notifier);
                     final state = ref.read(calendarViewModelProvider);
 
                     final start = state.startDay;
@@ -86,9 +79,9 @@ class CalendarPage extends ConsumerWidget {
                         ),
                       );
                     } else {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        const SnackBar(content: Text('여행 날짜를 선택해주세요.')),
-                      );
+                      ScaffoldMessenger.of(
+                        context,
+                      ).showSnackBar(const SnackBar(content: Text('여행 날짜를 선택해주세요.')));
                     }
                   },
 

--- a/lib/views/plan/plan/location_setting/district_setting_page.dart
+++ b/lib/views/plan/plan/location_setting/district_setting_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/utills/region_data.dart';
 import 'package:travel_muse_app/views/plan/plan/location_setting/widgets/district_box_list.dart';
 import 'package:travel_muse_app/views/plan/plan/location_setting/widgets/save_button.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class DistrictSettingPage extends ConsumerStatefulWidget {
   const DistrictSettingPage({super.key, required this.selectedProvince});
@@ -27,13 +28,8 @@ class DistrictSettingPageState extends ConsumerState<DistrictSettingPage> {
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
-        title: const Text(
-          '여행 일정 등록',
-          style: TextStyle(fontWeight: FontWeight.bold),
-        ),
-        backgroundColor: Colors.white,
-        foregroundColor: Colors.black,
-        elevation: 0.5,
+        title: const Text('여행 일정 등록'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
       ),
       body: SafeArea(
         child: Padding(
@@ -51,8 +47,7 @@ class DistrictSettingPageState extends ConsumerState<DistrictSettingPage> {
               Expanded(
                 child: DistrictBoxList(
                   items: districts,
-                  selectedIndices:
-                      selectedIndex != null ? {selectedIndex!} : {},
+                  selectedIndices: selectedIndex != null ? {selectedIndex!} : {},
                   onTap: (index) {
                     setState(() {
                       selectedIndex = index;

--- a/lib/views/plan/plan/location_setting/province_setting_page.dart
+++ b/lib/views/plan/plan/location_setting/province_setting_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/utills/region_data.dart';
 import 'package:travel_muse_app/views/plan/plan/location_setting/widgets/next_button.dart';
 import 'package:travel_muse_app/views/plan/plan/location_setting/widgets/province_box_list.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class ProvinceSettingPage extends ConsumerStatefulWidget {
   const ProvinceSettingPage({super.key});
@@ -19,14 +20,8 @@ class ProvinceSettingPageState extends ConsumerState<ProvinceSettingPage> {
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
-        title: Text(
-          '여행 일정 등록',
-          style: TextStyle(
-            fontWeight: FontWeight.bold,
-            color: Colors.grey[800],
-          ),
-        ),
-        backgroundColor: Colors.white,
+        title: const Text('여행 일정 등록'),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
       ),
       body: SafeArea(
         child: Padding(
@@ -45,8 +40,7 @@ class ProvinceSettingPageState extends ConsumerState<ProvinceSettingPage> {
                 child: ProvinceBoxList(
                   items: provinces,
                   emojis: emojis,
-                  selectedIndices:
-                      selectedIndex != null ? {selectedIndex!} : {},
+                  selectedIndices: selectedIndex != null ? {selectedIndex!} : {},
                   onTap: (index) {
                     setState(() {
                       selectedIndex = index;

--- a/lib/views/plan/plan/widgets/schedule_app_bar.dart
+++ b/lib/views/plan/plan/widgets/schedule_app_bar.dart
@@ -15,9 +15,8 @@ class ScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return AppBar(
-      leading: IconButton(
-        icon: const Icon(Icons.chevron_left),
-        onPressed: () async {
+      leading: GestureDetector(
+        onTap: () async {
           final shouldPop = await showDialog<bool>(
             context: context,
             builder:
@@ -31,6 +30,19 @@ class ScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
             Navigator.of(context).pop();
           }
         },
+
+        child: Container(
+          padding: EdgeInsets.only(top: 4),
+          width: 44,
+          height: 44,
+          color: Colors.amber,
+          child: SvgPicture.asset(
+            'assets/icons/chevron-left.svg',
+            width: 24,
+            height: 24,
+            fit: BoxFit.scaleDown,
+          ),
+        ),
       ),
 
       title: Text(
@@ -47,11 +59,7 @@ class ScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
         Padding(
           padding: const EdgeInsets.only(right: 16),
           child: GestureDetector(
-            child: SvgPicture.asset(
-              'assets/icons/map.svg',
-              width: 28,
-              height: 28,
-            ),
+            child: SvgPicture.asset('assets/icons/map.svg', width: 28, height: 28),
             onTap: () async {
               final hasRoute = await ref
                   .read(scheduleViewModelProvider.notifier)
@@ -60,10 +68,10 @@ class ScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
               if (!hasRoute) {
                 if (context.mounted) {
                   CustomToast.show(
-                                context: context,
-                                message: '일정을 먼저 등록해주세요.',
-                                duration: const Duration(seconds: 2),
-                              );
+                    context: context,
+                    message: '일정을 먼저 등록해주세요.',
+                    duration: const Duration(seconds: 2),
+                  );
                 }
                 return;
               }

--- a/lib/views/plan/plan/widgets/schedule_app_bar.dart
+++ b/lib/views/plan/plan/widgets/schedule_app_bar.dart
@@ -7,7 +7,8 @@ import 'package:travel_muse_app/providers/plan/schedule/schedule_provider.dart';
 import 'package:travel_muse_app/views/plan/location/map_page.dart';
 import 'package:travel_muse_app/views/plan/plan/schedule/widgets/schedule_confirm_dialog.dart';
 
-class ScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
+class ScheduleAppBar extends ConsumerWidget
+    implements PreferredSizeWidget {
   const ScheduleAppBar({super.key, required this.planId});
 
   final String planId;
@@ -35,7 +36,7 @@ class ScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
           padding: EdgeInsets.only(top: 4),
           width: 44,
           height: 44,
-          color: Colors.amber,
+          color: Colors.transparent,
           child: SvgPicture.asset(
             'assets/icons/chevron-left.svg',
             width: 24,
@@ -59,7 +60,11 @@ class ScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
         Padding(
           padding: const EdgeInsets.only(right: 16),
           child: GestureDetector(
-            child: SvgPicture.asset('assets/icons/map.svg', width: 28, height: 28),
+            child: SvgPicture.asset(
+              'assets/icons/map.svg',
+              width: 28,
+              height: 28,
+            ),
             onTap: () async {
               final hasRoute = await ref
                   .read(scheduleViewModelProvider.notifier)
@@ -78,7 +83,9 @@ class ScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
               if (context.mounted) {
                 await Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (_) => MapPage(planId: planId)),
+                  MaterialPageRoute(
+                    builder: (_) => MapPage(planId: planId),
+                  ),
                 );
               }
             },

--- a/lib/views/post/post_detail_page.dart
+++ b/lib/views/post/post_detail_page.dart
@@ -13,23 +13,29 @@ import 'package:travel_muse_app/providers/scoial/report_provider.dart';
 import 'package:travel_muse_app/views/post/%08comment/comment_section.dart';
 import 'package:travel_muse_app/views/post/post_write_page.dart';
 import 'package:travel_muse_app/views/post/widgets/detail/place_preview_card.dart';
-import 'package:travel_muse_app/views/post/widgets/detail/post_detail_appbar.dart';
 import 'package:travel_muse_app/views/post/widgets/detail/post_detail_content.dart';
 import 'package:travel_muse_app/views/post/widgets/detail/post_detail_header.dart';
 import 'package:travel_muse_app/views/post/widgets/detail/post_detail_images.dart';
 import 'package:travel_muse_app/views/post/widgets/detail/post_detail_tags_and_meta.dart';
 import 'package:travel_muse_app/views/post/widgets/detail/show_report_reason_dialog.dart';
 import 'package:travel_muse_app/views/post/widgets/write/confirm_dialog.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class PostDetailPage extends ConsumerStatefulWidget {
-  const PostDetailPage({super.key, this.post, this.postId, this.scrollToCommentId});
+  const PostDetailPage({
+    super.key,
+    this.post,
+    this.postId,
+    this.scrollToCommentId,
+  });
 
   final Post? post;
   final String? postId;
   final String? scrollToCommentId;
 
   @override
-  ConsumerState<PostDetailPage> createState() => _PostDetailPageState();
+  ConsumerState<PostDetailPage> createState() =>
+      _PostDetailPageState();
 }
 
 class _PostDetailPageState extends ConsumerState<PostDetailPage> {
@@ -64,7 +70,9 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
       await postRepo.incrementViewCount(currentPost.postId);
 
       // 최신 게시글 정보 다시 불러옴
-      final updatedPost = await postRepo.fetchPostById(currentPost.postId);
+      final updatedPost = await postRepo.fetchPostById(
+        currentPost.postId,
+      );
       if (updatedPost != null) {
         setState(() {
           currentPost = updatedPost;
@@ -84,7 +92,9 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
 
   Future<void> _refreshPost() async {
     final postRepo = ref.read(postRepositoryProvider);
-    final updatedPost = await postRepo.fetchPostById(currentPost.postId);
+    final updatedPost = await postRepo.fetchPostById(
+      currentPost.postId,
+    );
     if (updatedPost != null) {
       setState(() {
         currentPost = updatedPost;
@@ -124,18 +134,23 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
                           final result = await Navigator.push(
                             context,
                             MaterialPageRoute(
-                              builder: (_) => PostWritePage(post: currentPost),
+                              builder:
+                                  (_) => PostWritePage(
+                                    post: currentPost,
+                                  ),
                             ),
                           );
 
                           if (result == true && mounted) {
-                            final postRepo = ref.read(postRepositoryProvider);
-                            final updatedPost = await postRepo.fetchPostById(
-                              currentPost.postId,
+                            final postRepo = ref.read(
+                              postRepositoryProvider,
                             );
+                            final updatedPost = await postRepo
+                                .fetchPostById(currentPost.postId);
                             if (updatedPost != null) {
                               setState(() {
-                                currentPost = updatedPost; // 상세 페이지 갱신
+                                currentPost =
+                                    updatedPost; // 상세 페이지 갱신
                               });
                               Navigator.pop(context, updatedPost);
                             }
@@ -206,9 +221,14 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
                         ),
                         onTap: () {
                           Navigator.pop(context);
-                          showReportReasonDialog(context, (reasonCode, reasonText) async {
+                          showReportReasonDialog(context, (
+                            reasonCode,
+                            reasonText,
+                          ) async {
                             await ref
-                                .read(reportViewModelProvider.notifier)
+                                .read(
+                                  reportViewModelProvider.notifier,
+                                )
                                 .submit(
                                   targetType: 'post',
                                   targetId: currentPost.postId,
@@ -264,7 +284,10 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
       },
       child: Scaffold(
         appBar: AppBar(
-          leading: Navigator.canPop(context) ? const CustomBackButton() : null,
+          leading:
+              Navigator.canPop(context)
+                  ? const CustomBackButton()
+                  : null,
           actions: [
             GestureDetector(
               onTap: () {
@@ -289,9 +312,15 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: ListView(
             children: [
-              PostDetailHeader(nickname: nickname, profileUrl: profileUrl),
+              PostDetailHeader(
+                nickname: nickname,
+                profileUrl: profileUrl,
+              ),
               const SizedBox(height: 16),
-              PostDetailContent(title: currentPost.title, content: currentPost.content),
+              PostDetailContent(
+                title: currentPost.title,
+                content: currentPost.content,
+              ),
               const SizedBox(height: 16),
               PostDetailImages(images: currentPost.images),
               const SizedBox(height: 16),
@@ -311,7 +340,10 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
                 likeCount: currentPost.likeCount,
                 isLiked: ref.watch(
                   likeViewModelProvider(
-                    LikeViewModelParams(postId: currentPost.postId, userId: user.uid),
+                    LikeViewModelParams(
+                      postId: currentPost.postId,
+                      userId: user.uid,
+                    ),
                   ),
                 ),
                 onLikePressed: () async {
@@ -320,7 +352,9 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
                     userId: user.uid,
                   );
 
-                  final likeVM = ref.read(likeViewModelProvider(params).notifier);
+                  final likeVM = ref.read(
+                    likeViewModelProvider(params).notifier,
+                  );
 
                   await likeVM.toggleLike();
 

--- a/lib/views/post/post_detail_page.dart
+++ b/lib/views/post/post_detail_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/models/post/post_model.dart';
 import 'package:travel_muse_app/providers/post/like_provider.dart';
@@ -20,12 +21,7 @@ import 'package:travel_muse_app/views/post/widgets/detail/show_report_reason_dia
 import 'package:travel_muse_app/views/post/widgets/write/confirm_dialog.dart';
 
 class PostDetailPage extends ConsumerStatefulWidget {
-  const PostDetailPage({
-    super.key,
-    this.post,
-    this.postId,
-    this.scrollToCommentId,
-  });
+  const PostDetailPage({super.key, this.post, this.postId, this.scrollToCommentId});
 
   final Post? post;
   final String? postId;
@@ -209,10 +205,7 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
                         ),
                         onTap: () {
                           Navigator.pop(context);
-                          showReportReasonDialog(context, (
-                            reasonCode,
-                            reasonText,
-                          ) async {
+                          showReportReasonDialog(context, (reasonCode, reasonText) async {
                             await ref
                                 .read(reportViewModelProvider.notifier)
                                 .submit(
@@ -276,10 +269,7 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
             children: [
               PostDetailHeader(nickname: nickname, profileUrl: profileUrl),
               const SizedBox(height: 16),
-              PostDetailContent(
-                title: currentPost.title,
-                content: currentPost.content,
-              ),
+              PostDetailContent(title: currentPost.title, content: currentPost.content),
               const SizedBox(height: 16),
               PostDetailImages(images: currentPost.images),
               const SizedBox(height: 16),
@@ -299,10 +289,7 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
                 likeCount: currentPost.likeCount,
                 isLiked: ref.watch(
                   likeViewModelProvider(
-                    LikeViewModelParams(
-                      postId: currentPost.postId,
-                      userId: user.uid,
-                    ),
+                    LikeViewModelParams(postId: currentPost.postId, userId: user.uid),
                   ),
                 ),
                 onLikePressed: () async {
@@ -311,9 +298,7 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
                     userId: user.uid,
                   );
 
-                  final likeVM = ref.read(
-                    likeViewModelProvider(params).notifier,
-                  );
+                  final likeVM = ref.read(likeViewModelProvider(params).notifier);
 
                   await likeVM.toggleLike();
 
@@ -325,6 +310,7 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
             ],
           ),
         ),
+        bottomNavigationBar: const BottomBar(),
       ),
     );
   }

--- a/lib/views/post/post_detail_page.dart
+++ b/lib/views/post/post_detail_page.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
@@ -262,7 +263,28 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
         return false;
       },
       child: Scaffold(
-        appBar: buildPostDetailAppBar(_showOptions),
+        appBar: AppBar(
+          leading: Navigator.canPop(context) ? const CustomBackButton() : null,
+          actions: [
+            GestureDetector(
+              onTap: () {
+                _showOptions();
+              },
+              child: Container(
+                padding: EdgeInsets.only(top: 6),
+                width: 44,
+                height: 44,
+                color: Colors.transparent,
+                child: SvgPicture.asset(
+                  'assets/icons/more-vertical.svg',
+                  width: 24,
+                  height: 24,
+                  fit: BoxFit.scaleDown,
+                ),
+              ),
+            ),
+          ],
+        ),
         body: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: ListView(

--- a/lib/views/post/post_list_page.dart
+++ b/lib/views/post/post_list_page.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
-import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/views/post/widgets/list/post_list_view.dart';
 import 'package:travel_muse_app/views/post/widgets/list/post_search_page.dart';
 import 'package:travel_muse_app/views/post/widgets/list/tag_bar.dart';
 import 'package:travel_muse_app/views/post/widgets/write/write_fab.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class PostListPage extends StatefulWidget {
   const PostListPage({super.key});
@@ -23,23 +23,7 @@ class _PostListPageState extends State<PostListPage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('커뮤니티'),
-        centerTitle: false,
-        titleTextStyle: AppTextStyles.appBarTitle,
-        leading: Padding(
-          padding: const EdgeInsets.only(top: 5),
-          child: Center(
-            child: IconButton(
-              icon: SvgPicture.asset(
-                'assets/icons/chevron-left.svg',
-                width: 24,
-                height: 24,
-              ),
-              onPressed: () {
-                Navigator.pop(context);
-              },
-            ),
-          ),
-        ),
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
         actions: [
           Padding(
             padding: const EdgeInsets.only(right: 15),
@@ -48,7 +32,7 @@ class _PostListPageState extends State<PostListPage> {
                 'assets/icons/search.svg',
                 width: 24,
                 height: 24,
-                color: AppColors.grey[700], 
+                color: AppColors.grey[700],
               ),
               onPressed: () {
                 Navigator.push(

--- a/lib/views/post/widgets/list/post_search_page.dart
+++ b/lib/views/post/widgets/list/post_search_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/views/post/widgets/list/post_list_view.dart';
 import 'package:travel_muse_app/views/post/widgets/list/post_search_bar.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class PostSearchPage extends StatefulWidget {
   const PostSearchPage({super.key});
@@ -15,7 +16,9 @@ class _PostSearchPageState extends State<PostSearchPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(),
+      appBar: AppBar(
+        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
+      ),
       body: Column(
         children: [
           PostSearchBar(

--- a/lib/views/preference/preference_test_page.dart
+++ b/lib/views/preference/preference_test_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
-import 'package:travel_muse_app/core/widgets/svg_icon.dart';
+import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/viewmodels/preference/preference_test_view_model.dart';
 import 'package:travel_muse_app/views/preference/widgets/next_button.dart';
 import 'package:travel_muse_app/views/preference/widgets/page_indicator_bar.dart';
@@ -79,47 +81,53 @@ class _PreferenceTestPageState extends ConsumerState<PreferenceTestPage> {
       backgroundColor: AppColors.white,
       navigationBar: CupertinoNavigationBar(
         automaticallyImplyLeading: false,
-        backgroundColor: AppColors.primary[300],
+        backgroundColor: Colors.white,
         border: null,
-        leading: GestureDetector(
-          onTap: () {
-            if (_currentIndex > 0) {
-              setState(() {
-                _currentIndex--;
-                _selectedOption = null;
-              });
-            } else {
-              Navigator.pop(context);
-            }
-          },
-          child: Padding(
-            padding: const EdgeInsets.only(left: 16),
-            child: Row(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                SvgIcon.arrow(width: 27, height: 27),
-                const SizedBox(width: 8),
-                Text(
-                  '여행성향 테스트',
-                  style: TextStyle(
-                    color: AppColors.grey[800],
-                    fontSize: 18,
-                    fontWeight: FontWeight.w600,
+        leading: Padding(
+          padding: const EdgeInsets.only(left: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              GestureDetector(
+                onTap: () {
+                  if (_currentIndex > 0) {
+                    setState(() {
+                      _currentIndex--;
+                      _selectedOption = null;
+                    });
+                  } else {
+                    Navigator.pop(context);
+                  }
+                },
+                behavior: HitTestBehavior.opaque,
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 4.0),
+                  child: Container(
+                    width: 24,
+                    height: 44,
+                    color: Colors.transparent,
+                    child: Center(
+                      child: SvgPicture.asset(
+                        'assets/icons/chevron-left.svg',
+                        width: 24,
+                        height: 24,
+                        fit: BoxFit.scaleDown,
+                      ),
+                    ),
                   ),
                 ),
-              ],
-            ),
+              ),
+              SizedBox(width: 16),
+              Text('여행성향 테스트', style: AppTextStyles.appBarTitle),
+            ],
           ),
         ),
       ),
       child: SafeArea(
         child:
             isFinished
-                ? ResultView(
-                  onRestart: _restartTest,
-                  showButtons: true,
-                  testId: '',
-                )
+                ? ResultView(onRestart: _restartTest, showButtons: true, testId: '')
                 : Column(
                   children: [
                     Expanded(
@@ -137,10 +145,7 @@ class _PreferenceTestPageState extends ConsumerState<PreferenceTestPage> {
                       ),
                     ),
                     Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 8,
-                      ),
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
                       child: NextButton(
                         onPressed: _onNextPressed,
                         enabled: _selectedOption != null,

--- a/lib/views/preference/widgets/result_view.dart
+++ b/lib/views/preference/widgets/result_view.dart
@@ -7,6 +7,7 @@ import 'package:travel_muse_app/providers/preference/preference_test_provider.da
 import 'package:travel_muse_app/providers/user/app_user_view_model_provider.dart';
 import 'package:travel_muse_app/views/preference/widgets/result_action_buttons.dart';
 import 'package:travel_muse_app/views/preference/widgets/result_view_detail.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
 class ResultView extends ConsumerStatefulWidget {
   const ResultView({
@@ -39,9 +40,7 @@ class _ResultViewState extends ConsumerState<ResultView> {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (widget.testId != '') {
-        ref
-            .read(preferenceTestStateNotifierProvider.notifier)
-            .loadTest(widget.testId);
+        ref.read(preferenceTestStateNotifierProvider.notifier).loadTest(widget.testId);
       }
     });
   }
@@ -65,6 +64,7 @@ class _ResultViewState extends ConsumerState<ResultView> {
           !widget.showButtons
               ? AppBar(
                 title: const Text('나의 여행 성향'),
+                leading: Navigator.canPop(context) ? const CustomBackButton() : null,
                 actions: [
                   PopupMenuButton<String>(
                     color: Colors.white,
@@ -87,8 +87,7 @@ class _ResultViewState extends ConsumerState<ResultView> {
                                   ),
                                 ],
                                 cancelButton: CupertinoActionSheetAction(
-                                  onPressed:
-                                      () => Navigator.pop(context, false),
+                                  onPressed: () => Navigator.pop(context, false),
                                   child: const Text('취소'),
                                 ),
                               ),
@@ -96,9 +95,7 @@ class _ResultViewState extends ConsumerState<ResultView> {
 
                         if (confirm == true) {
                           await ref
-                              .read(
-                                preferenceTestStateNotifierProvider.notifier,
-                              )
+                              .read(preferenceTestStateNotifierProvider.notifier)
                               .deleteTest(widget.testId);
                           if (context.mounted) {
                             /// 리스트 Provider invalidate
@@ -120,10 +117,7 @@ class _ResultViewState extends ConsumerState<ResultView> {
                         (_) => [
                           const PopupMenuItem<String>(
                             value: 'delete',
-                            child: Text(
-                              '삭제',
-                              style: TextStyle(color: Colors.red),
-                            ),
+                            child: Text('삭제', style: TextStyle(color: Colors.red)),
                           ),
                         ],
                   ),
@@ -138,10 +132,7 @@ class _ResultViewState extends ConsumerState<ResultView> {
                 ListView(
                   children: [
                     Padding(
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 24,
-                      ),
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: [
@@ -197,9 +188,7 @@ class _ResultViewState extends ConsumerState<ResultView> {
                       onPressed: () {
                         Navigator.push(
                           context,
-                          CupertinoPageRoute(
-                            builder: (_) => const ResultViewDetail(),
-                          ),
+                          CupertinoPageRoute(builder: (_) => const ResultViewDetail()),
                         );
                       },
                       child: Row(

--- a/lib/views/user/onboarding/terms_web_view_page.dart
+++ b/lib/views/user/onboarding/terms_web_view_page.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 class TermsWebViewPage extends StatefulWidget {
-  const TermsWebViewPage({super.key, required this.title, required this.url});
+  const TermsWebViewPage({
+    super.key,
+    required this.title,
+    required this.url,
+  });
 
   final String title;
   final String url;
@@ -27,10 +32,11 @@ class _TermsWebViewPageState extends State<TermsWebViewPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.title, style: TextStyle(color: Colors.black)),
-        backgroundColor: Colors.white,
-        foregroundColor: Colors.black,
-        elevation: 1,
+        title: Text(widget.title),
+        leading:
+            Navigator.canPop(context)
+                ? const CustomBackButton()
+                : null,
       ),
       body: WebViewWidget(key: UniqueKey(), controller: _controller),
     );

--- a/lib/views/widgets/custom_back_button.dart
+++ b/lib/views/widgets/custom_back_button.dart
@@ -13,7 +13,7 @@ class CustomBackButton extends StatelessWidget {
         padding: EdgeInsets.only(top: 4),
         width: 44,
         height: 44,
-        color: Colors.amber,
+        color: Colors.transparent,
         child: SvgPicture.asset(
           'assets/icons/chevron-left.svg',
           width: 24,

--- a/lib/views/widgets/custom_back_button.dart
+++ b/lib/views/widgets/custom_back_button.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+class CustomBackButton extends StatelessWidget {
+  const CustomBackButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () => Navigator.of(context).maybePop(),
+
+      child: Container(
+        padding: EdgeInsets.only(top: 4),
+        width: 44,
+        height: 44,
+        color: Colors.amber,
+        child: SvgPicture.asset(
+          'assets/icons/chevron-left.svg',
+          width: 24,
+          height: 24,
+          fit: BoxFit.scaleDown,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/widgets/edit_nickname.dart
+++ b/lib/views/widgets/edit_nickname.dart
@@ -35,6 +35,10 @@ class EditNickname extends ConsumerWidget {
                             .checkNicknameChanged(value);
                       },
                       textAlignVertical: TextAlignVertical.center,
+                      style: TextStyle(
+                        fontFamily: 'Pretendard',
+                        fontWeight: FontWeight.w700,
+                      ),
                       decoration: InputDecoration(
                         contentPadding: EdgeInsets.symmetric(
                           vertical: 16,
@@ -58,10 +62,7 @@ class EditNickname extends ConsumerWidget {
           SizedBox(
             child: Text(
               state.nicknameMessage ?? '',
-              style:
-                  showAsError
-                      ? AppTextStyles.errorText
-                      : AppTextStyles.helperText,
+              style: showAsError ? AppTextStyles.errorText : AppTextStyles.helperText,
             ),
           ),
         ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -796,10 +796,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.9"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -1321,10 +1321,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
### 🚀: 개요
- 텍스트폼필드 내부 텍스트, 바텀바, 앱바 피그마 적용
- 
### 🚀: 작업 내용
- EditNickname 텍스트폼필드 내부 텍스트 피그마 디자인 적용
- 바텀바 누락된 페이지에 바텀바 추가
- appBarTheme설정
- 앱바 뒤로가기 아이콘 피그마 디자인 적용

### 📸: 실행 화면
<img src="https://github.com/user-attachments/assets/2735f5bc-73f8-44b7-9f37-973b31306910" width="300" height="640"/>
<img src="https://github.com/user-attachments/assets/3083ab16-2f63-4ca4-b128-871282206688" width="300" height="640"/>

### 🚀: 조정 파일
- custom_back_button.dart
- main.dart
- appbar사용하는 모든 페이지 view 파일

### 개발 결과
- EditNickname 텍스트폼필드 내부 텍스트 피그마 디자인 적용
- 바텀바 누락된 페이지에 바텀바 추가
- appBarTheme설정
- 앱바 뒤로가기 아이콘 피그마 디자인 적용

### issue
Closes #255
