### PR TITLE
[AI]AI 추천 플랜아이디당 3회 제한, Kakao API 병렬 처리, 성향 테스트 캐싱 및 50회 제한 적용

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1716,15 +1716,15 @@ SPEC CHECKSUMS:
   AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
   AppCheckCore: cc8fd0a3a230ddd401f326489c99990b013f0c4f
   BoringSSL-GRPC: dded2a44897e45f28f08ae87a55ee4bcd19bc508
-  cloud_firestore: 41c1ea0ea7b3f9b50a8fe27a59009b65b7ce7404
-  cloud_functions: 68d67463cf7985ad374b4e58113976de4836372f
+  cloud_firestore: 5c68298ed4398ab73ca3333ab99699add650ec1c
+  cloud_functions: 9c4252b4a2372f96feb0bf5368e1b850c47505ca
   Firebase: 3435bc66b4d494c2f22c79fd3aae4c1db6662327
-  firebase_analytics: 9bc12534b28e9955a6d02fac0478e92e027aed26
-  firebase_app_check: 94695458302cf6bb83b197c5b9afc09fd08181dd
-  firebase_auth: a9855fe79286576c5225b28aafed65bc374ac19a
-  firebase_core: a861be150c0e7c6aecedde077968eb92cbf790b9
-  firebase_crashlytics: aa26a226ac9a7047f729701fd8a60028a21f84ac
-  firebase_storage: 104d0dcc79a12fecc634a3cb725f7f174430cd58
+  firebase_analytics: 4af7b20cf0c2da4e0473117e01a69507db8d7c16
+  firebase_app_check: 9dd264a91837205c607bb2abc6bb3e71b5071bb7
+  firebase_auth: ebc1f561cc3077efebad5005974c9ed58008973b
+  firebase_core: 700bac7ed92bb754fd70fbf01d72b36ecdd6d450
+  firebase_crashlytics: d101fbdc2dba187f483f13ae3ce9281779d664db
+  firebase_storage: 54cc3c866fe4cb619bacb774bb946014e7609625
   FirebaseAnalytics: 630349facf4a114a0977e5d7570e104261973287
   FirebaseAppCheck: 6097c3bdf50028493a86b28297d0f1f3309c0741
   FirebaseAppCheckInterop: a92ba81d0ee3c4cddb1a2e52c668ea51dc63c3ae
@@ -1744,13 +1744,13 @@ SPEC CHECKSUMS:
   FirebaseSharedSwift: bdd5c8674c4712a98e70287c936bc5cca5d640f6
   FirebaseStorage: 2a3e5402a565e06e121308dadfe0626976fd6b45
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_image_compress_common: ec1d45c362c9d30a3f6a0426c297f47c52007e3e
-  flutter_local_notifications: ff50f8405aaa0ccdc7dcfb9022ca192e8ad9688f
-  fluttertoast: 21eecd6935e7064cc1fcb733a4c5a428f3f24f0f
-  geolocator_apple: 66b711889fd333205763b83c9dcf0a57a28c7afd
+  flutter_image_compress_common: 1697a328fd72bfb335507c6bca1a65fa5ad87df1
+  flutter_local_notifications: a5a732f069baa862e728d839dd2ebb904737effb
+  fluttertoast: 2c67e14dce98bbdb200df9e1acf610d7a6264ea1
+  geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   Google-Maps-iOS-Utils: 66d6de12be1ce6d3742a54661e7a79cb317a9321
-  google_maps_flutter_ios: e31555a04d1986ab130f2b9f24b6cdc861acc6d3
-  google_sign_in_ios: 7411fab6948df90490dc4620ecbcabdc3ca04017
+  google_maps_flutter_ios: 0291eb2aa252298a769b04d075e4a9d747ff7264
+  google_sign_in_ios: b48bb9af78576358a168361173155596c845f0b9
   GoogleAppMeasurement: 0dfca1a4b534d123de3945e28f77869d10d0d600
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleMaps: 8939898920281c649150e0af74aa291c60f2e77d
@@ -1760,22 +1760,22 @@ SPEC CHECKSUMS:
   gRPC-Core: 860978b7db482de8b4f5e10677216309b5ff6330
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
-  image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
+  image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
   leveldb-library: cc8b8f8e013647a295ad3f8cd2ddf49a6f19be19
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   Mantle: c5aa8794a29a022dfbbfc9799af95f477a69b62d
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
-  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
   PromisesSwift: 9d77319bbe72ebf6d872900551f7eeba9bce2851
   RecaptchaInterop: 11e0b637842dfb48308d242afc3f448062325aba
   SDWebImage: f29024626962457f3470184232766516dee8dfea
   SDWebImageWebPCoder: e38c0a70396191361d60c092933e22c20d5b1380
-  shared_preferences_foundation: fcdcbc04712aee1108ac7fda236f363274528f78
-  sign_in_with_apple: f3bf75217ea4c2c8b91823f225d70230119b8440
-  url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
-  webview_flutter_wkwebview: a4af96a051138e28e29f60101d094683b9f82188
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418
+  url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
+  webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
 
 PODFILE CHECKSUM: 07ebf3f572f507bd575af81066430d274ad6951f
 

--- a/lib/core/ai_route_helper.dart
+++ b/lib/core/ai_route_helper.dart
@@ -23,7 +23,7 @@ Future<void> generateAndSaveEnrichedAiRoute({
     context: context,
   );
 
-  // 파싱 (기존 _parseAiPlan 로직과 동일)
+  // 파싱
   final lines = aiPlan.split('\n');
   final parsed = <int, List<Map<String, String>>>{};
   int? currentDay;
@@ -43,34 +43,39 @@ Future<void> generateAndSaveEnrichedAiRoute({
     }
   }
 
-  // Kakao API로 lat/lng/image enrich
+  // Kakao API로 lat/lng/image enrich (병렬 처리 적용)
   final enriched = <int, List<Map<String, String>>>{};
 
   for (final entry in parsed.entries) {
     final day = entry.key;
-    final enrichedPlaces = <Map<String, String>>[];
+    final places = entry.value;
 
-    for (final place in entry.value) {
-      final title = place['title']!;
-      final description = place['description'] ?? '';
+    // 각 장소 enrich 작업 병렬 처리
+    final enrichedPlaces = await Future.wait(
+      places.map((place) async {
+        final title = place['title']!;
+        final description = place['description'] ?? '';
 
-      final kakaoResults = await placeService.search('$region $title');
-      final firstPlace = kakaoResults.isNotEmpty ? kakaoResults.first : null;
+        final kakaoResults = await placeService.search('$region $title');
+        final firstPlace = kakaoResults.isNotEmpty ? kakaoResults.first : null;
 
-      final imageUrl = await placeService.fetchImageThumbnail('$region $title');
+        final imageUrl = await placeService.fetchImageThumbnail(
+          '$region $title',
+        );
 
-      enrichedPlaces.add({
-        'title': title,
-        'description': description,
-        'lat': '${firstPlace?.latitude ?? 0.0}',
-        'lng': '${firstPlace?.longitude ?? 0.0}',
-        'image': imageUrl ?? '',
-        'subtitle':
-            firstPlace != null
-                ? '${firstPlace.city} ${firstPlace.district} • ${firstPlace.category}'
-                : '',
-      });
-    }
+        return {
+          'title': title,
+          'description': description,
+          'lat': '${firstPlace?.latitude ?? 0.0}',
+          'lng': '${firstPlace?.longitude ?? 0.0}',
+          'image': imageUrl ?? '',
+          'subtitle':
+              firstPlace != null
+                  ? '${firstPlace.city} ${firstPlace.district} • ${firstPlace.category}'
+                  : '',
+        };
+      }).toList(),
+    );
 
     enriched[day] = enrichedPlaces;
   }

--- a/lib/models/preference/preference_test_model.dart
+++ b/lib/models/preference/preference_test_model.dart
@@ -1,7 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 class PreferenceAnswer {
-
   PreferenceAnswer({required this.questionId, required this.selectedOption});
 
   factory PreferenceAnswer.fromMap(Map<String, dynamic> map) {
@@ -10,6 +9,7 @@ class PreferenceAnswer {
       selectedOption: map['selectedOption'] ?? '',
     );
   }
+
   final String questionId;
   final String selectedOption;
 
@@ -20,7 +20,6 @@ class PreferenceAnswer {
 }
 
 class PreferenceTest {
-
   PreferenceTest({
     required this.testId,
     required this.userId,
@@ -28,6 +27,7 @@ class PreferenceTest {
     required this.result,
     required this.createdAt,
     required this.updatedAt,
+    this.answersHash,
   });
 
   ///Firestore에서 가져올 때 사용
@@ -42,8 +42,10 @@ class PreferenceTest {
       result: Map<String, String>.from(map['result']),
       createdAt: (map['createAt'] as Timestamp).toDate(),
       updatedAt: (map['updateAt'] as Timestamp).toDate(),
+      answersHash: map['answersHash'],
     );
   }
+
   final String testId;
   final String userId;
   final List<PreferenceAnswer> answers;
@@ -51,6 +53,7 @@ class PreferenceTest {
   result; // e.g., {'type': 'a', 'details': '계획형 여행가 ...'}
   final DateTime createdAt;
   final DateTime updatedAt;
+  final String? answersHash;
 
   Map<String, dynamic> toMap() => {
     'testId': testId,
@@ -59,6 +62,7 @@ class PreferenceTest {
     'result': result,
     'createAt': createdAt,
     'updateAt': updatedAt,
+    'answersHash': answersHash,
   };
 
   /// copyWith 메서드
@@ -69,6 +73,7 @@ class PreferenceTest {
     Map<String, String>? result,
     DateTime? createdAt,
     DateTime? updatedAt,
+    String? answersHash,
   }) {
     return PreferenceTest(
       testId: testId ?? this.testId,
@@ -77,6 +82,7 @@ class PreferenceTest {
       result: result ?? this.result,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
+      answersHash: answersHash ?? this.answersHash,
     );
   }
 }

--- a/lib/repositories/plan/plan_repository.dart
+++ b/lib/repositories/plan/plan_repository.dart
@@ -1,8 +1,10 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/services/plan/ai_service.dart';
 
 class PlanRepository {
   final _aiService = AiService();
+  final _firestore = FirebaseFirestore.instance;
 
   final Map<String, String> _typeDescriptions = {
     '계획러': '철두철미 계획러: 여행은 미리미리! 엑셀표까지 만들어야 마음이 놓이죠.',
@@ -51,5 +53,19 @@ Day N:
 ''';
 
     return await _aiService.generate(prompt, context);
+  }
+
+  /// AI 추천 횟수가 3회 미만인지 확인
+  Future<bool> isAiRecommendationAllowed(String planId) async {
+    final doc = await _firestore.collection('plans').doc(planId).get();
+    final count = (doc.data()?['ai_attempt_count'] ?? 0) as int;
+    return count < 3;
+  }
+
+  /// AI 추천 횟수 1 증가
+  Future<void> incrementAiAttemptCount(String planId) async {
+    await _firestore.collection('plans').doc(planId).set({
+      'ai_attempt_count': FieldValue.increment(1),
+    }, SetOptions(merge: true));
   }
 }

--- a/lib/repositories/preference/preference_test_repository.dart
+++ b/lib/repositories/preference/preference_test_repository.dart
@@ -84,4 +84,55 @@ class PreferenceTestRepository {
   Future<void> deleteTest(String testId) async {
     await _firestore.collection(_collection).doc(testId).delete();
   }
+
+  /// answersRaw → 해시 문자열로 변환
+  String generateAnswersHash(List<PreferenceAnswer> answers) {
+    return answers
+        .map((a) => '${a.questionId}:${a.selectedOption}')
+        .join('|')
+        .hashCode
+        .toString(); // 짧게 만들기 위해 hashCode 사용
+  }
+
+  /// 해시 기반 캐시 조회
+  Future<PreferenceTest?> findTestByAnswerHash(
+    String userId,
+    String answersHash,
+  ) async {
+    final query =
+        await _firestore
+            .collection(_collection)
+            .where('userId', isEqualTo: userId)
+            .where('answersHash', isEqualTo: answersHash)
+            .limit(1)
+            .get();
+
+    if (query.docs.isEmpty) return null;
+    final doc = query.docs.first;
+    return PreferenceTest.fromDoc(doc.id, doc.data());
+  }
+
+  /// 해시값 포함 저장 (saveTest 내부용으로 확장)
+  Future<String> saveTestWithHash(
+    PreferenceTest test,
+    String answersHash,
+  ) async {
+    final docRef = _firestore.collection(_collection).doc();
+    final data = test.copyWith(testId: docRef.id).toMap();
+    data['answersHash'] = answersHash; // 해시 추가
+    await docRef.set(data);
+    return docRef.id;
+  }
+
+  Future<bool> canTakeTest(String userId, {int limit = 50}) async {
+    final doc = await _firestore.collection('appUser').doc(userId).get();
+    final count = (doc.data()?['testCount'] ?? 0) as int;
+    return count < limit;
+  }
+
+  Future<void> incrementTestCount(String userId) async {
+    await _firestore.collection('appUser').doc(userId).set({
+      'testCount': FieldValue.increment(1),
+    }, SetOptions(merge: true));
+  }
 }

--- a/lib/services/preference/preference_test_service.dart
+++ b/lib/services/preference/preference_test_service.dart
@@ -1,10 +1,14 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
+import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/models/preference/preference_test_model.dart';
+import 'package:travel_muse_app/repositories/preference/preference_test_repository.dart';
 import 'package:travel_muse_app/services/plan/ai_service.dart';
 
 class PreferenceTestService {
   final _aiService = AiService();
+  final _repo = PreferenceTestRepository();
+
   final _typeDescriptions = {
     '계획러': '철두철미 계획러: 여행은 미리미리! 엑셀표까지 만들어야 마음이 놓이죠.',
     '자유인': '자유로운 방랑자: 즉흥 여행이 진짜 여행!',
@@ -22,7 +26,34 @@ class PreferenceTestService {
     if (user == null) {
       throw Exception('로그인되지 않은 상태입니다.');
     }
+    // 테스트 제한 체크
+    final allowed = await _repo.canTakeTest(user.uid);
+    if (!allowed) {
+      CustomToast.show(
+        // ignore: use_build_context_synchronously
+        context: context,
+        message: '성향 테스트는 계정당 최대 50회까지만 가능합니다.',
+      );
+      throw Exception('테스트 횟수 제한됨');
+    }
 
+    // 테스트 횟수 증가
+    await _repo.incrementTestCount(user.uid);
+    // 응답 파싱
+    final answers =
+        answersRaw.map((a) {
+          return PreferenceAnswer(
+            questionId: a['questionId']!,
+            selectedOption: a['selectedOption']!,
+          );
+        }).toList();
+
+    // 해시 생성 및 캐시 체크
+    final answersHash = _repo.generateAnswersHash(answers);
+    final cached = await _repo.findTestByAnswerHash(user.uid, answersHash);
+    if (cached != null) return cached;
+
+    // Gemini 호출
     final resultSummary = answersRaw
         .map((a) => '${a['question']} => ${a['selectedOption']}')
         .join(', ');
@@ -42,25 +73,23 @@ $resultSummary
 모험가: 체험형 모험가
 ''';
 
+    // ignore: use_build_context_synchronously
     final typeCode = await _aiService.getTypeCodeFromAI(prompt, context);
     final description = _typeDescriptions[typeCode] ?? '알 수 없는 유형';
     final now = DateTime.now();
 
-    final answers =
-        answersRaw.map((a) {
-          return PreferenceAnswer(
-            questionId: a['questionId']!,
-            selectedOption: a['selectedOption']!,
-          );
-        }).toList();
-
-    return PreferenceTest(
-      testId: '${user.uid}_${now.millisecondsSinceEpoch}',
+    final test = PreferenceTest(
+      testId: '',
       userId: user.uid,
       answers: answers,
       result: {'type': typeCode, 'details': description},
       createdAt: now,
       updatedAt: now,
+      answersHash: answersHash,
     );
+
+    // 저장 (해시 포함)
+    final newId = await _repo.saveTestWithHash(test, answersHash);
+    return test.copyWith(testId: newId);
   }
 }

--- a/lib/views/plan/plan/schedule/widgets/ai_button.dart
+++ b/lib/views/plan/plan/schedule/widgets/ai_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/repositories/plan/plan_repository.dart';
 import 'package:travel_muse_app/services/plan/place_search_service.dart';
 import 'package:travel_muse_app/views/plan/plan/schedule/widgets/ai_type_select_popup.dart';
@@ -25,59 +26,88 @@ class AiButton extends StatelessWidget {
       onTap: () {
         showDialog(
           context: context,
-          builder: (_) => AiTypeSelectPopup(
-            onComplete: (selectedTest) async {
-              final typeCode = selectedTest;
-              final planRepo = PlanRepository();
-              final placeService = PlaceSearchService();
+          builder:
+              (_) => AiTypeSelectPopup(
+                onComplete: (selectedTest) async {
+                  final typeCode = selectedTest;
+                  final planRepo = PlanRepository();
+                  final placeService = PlaceSearchService();
 
-              final aiPlan = await planRepo.getOptimizedPlanFromAI(
-                days: days,
-                region: region,
-                typeCode: typeCode,
-                context: context,
-              );
+                  // 호출 횟수 체크
+                  final allowed = await planRepo.isAiRecommendationAllowed(
+                    planId,
+                  );
+                  if (!allowed) {
+                    if (context.mounted) {
+                      CustomToast.show(
+                        context: context,
+                        message: 'AI 추천은 최대 3회까지만 가능합니다.',
+                      );
+                    }
+                    return;
+                  }
 
-              final parsed = _parseAiPlan(aiPlan);
+                  // 횟수 증가
+                  await planRepo.incrementAiAttemptCount(planId);
 
-              final enriched = <int, List<Map<String, String>>>{};
-              for (final entry in parsed.entries) {
-                final day = entry.key;
-                final enrichedPlaces = <Map<String, String>>[];
+                  final aiPlan = await planRepo.getOptimizedPlanFromAI(
+                    days: days,
+                    region: region,
+                    typeCode: typeCode,
+                    // ignore: use_build_context_synchronously
+                    context: context,
+                  );
 
-                for (final place in entry.value) {
-                  final title = place['title']!;
-                  final description = place['description'] ?? '';
+                  final parsed = _parseAiPlan(aiPlan);
 
-                  final kakaoResults = await placeService.search('$region $title');
-                  final firstPlace = kakaoResults.isNotEmpty ? kakaoResults.first : null;
-                  final imageUrl = await placeService.fetchImageThumbnail('$region $title');
+                  final enriched = <int, List<Map<String, String>>>{};
+                  for (final entry in parsed.entries) {
+                    final day = entry.key;
+                    final enrichedPlaces = <Map<String, String>>[];
 
-                  enrichedPlaces.add({
-                    'title': title,
-                    'description': description,
-                    'lat': '${firstPlace?.latitude ?? 0.0}',
-                    'lng': '${firstPlace?.longitude ?? 0.0}',
-                    'image': imageUrl ?? '',
-                    'subtitle': firstPlace != null
-                        ? '${firstPlace.city} ${firstPlace.district} • ${firstPlace.category}'
-                        : '',
-                  });
-                }
+                    for (final place in entry.value) {
+                      final title = place['title']!;
+                      final description = place['description'] ?? '';
 
-                enriched[day] = enrichedPlaces;
-              }
+                      final kakaoResults = await placeService.search(
+                        '$region $title',
+                      );
+                      final firstPlace =
+                          kakaoResults.isNotEmpty ? kakaoResults.first : null;
+                      final imageUrl = await placeService.fetchImageThumbnail(
+                        '$region $title',
+                      );
 
-              onResult(enriched); // Firestore 저장 없이 UI 상태만 전달
-            },
-          ),
+                      enrichedPlaces.add({
+                        'title': title,
+                        'description': description,
+                        'lat': '${firstPlace?.latitude ?? 0.0}',
+                        'lng': '${firstPlace?.longitude ?? 0.0}',
+                        'image': imageUrl ?? '',
+                        'subtitle':
+                            firstPlace != null
+                                ? '${firstPlace.city} ${firstPlace.district} • ${firstPlace.category}'
+                                : '',
+                      });
+                    }
+
+                    enriched[day] = enrichedPlaces;
+                  }
+
+                  onResult(enriched); // Firestore 저장 없이 UI 상태만 전달
+                },
+              ),
         );
       },
       child: Container(
         decoration: BoxDecoration(
           gradient: LinearGradient(
-            colors: [AppColors.primary[50]!, AppColors.primary[300]!, AppColors.primary[400]!],
-            stops: [0.0,0.3,0.7],
+            colors: [
+              AppColors.primary[50]!,
+              AppColors.primary[300]!,
+              AppColors.primary[400]!,
+            ],
+            stops: [0.0, 0.3, 0.7],
             begin: Alignment.centerLeft,
             end: Alignment.centerRight,
           ),

--- a/lib/views/preference/widgets/result_view.dart
+++ b/lib/views/preference/widgets/result_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/constants/app_text_styles.dart';
+import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/providers/preference/preference_test_provider.dart';
 import 'package:travel_muse_app/providers/user/app_user_view_model_provider.dart';
 import 'package:travel_muse_app/views/preference/widgets/result_action_buttons.dart';
@@ -107,8 +108,9 @@ class _ResultViewState extends ConsumerState<ResultView> {
                             /// 단건 상태 초기화
                             ref.invalidate(preferenceTestStateNotifierProvider);
 
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(content: Text('성향 테스트가 삭제되었습니다')),
+                            CustomToast.show(
+                              context: context,
+                              message: '성향 테스트가 삭제되었습니다',
                             );
 
                             Navigator.pop(context, 'deleted');


### PR DESCRIPTION
### 🚀: 개요  
- AI 추천받기 플랜아이디 당 3회 제한 
- Kakao API 병렬 처리 적용  
- 성향 테스트 결과 캐싱 및 계정당 최대 50회 제한 기능 추가  



### 🚀: 작업 내용  
- AI 추천받기 버튼에 Gemini 플랜아이디 3회 제한 및 Kakao 장소 API 병렬 처리 적용  

- PreferenceTest 모델에 answersHash 필드 추가 (캐싱 기준 해시값)  
- 같은 응답일 경우 Gemini API 호출 생략 → 기존 Firestore 결과 재사용  
- 계정당 테스트 50회 제한 (appUser.testCount 필드 관리)  
- 50회 초과 시 CustomToast로 사용자에게 안내  
- 기존 SnackBar 사용 → CustomToast 방식으로 통일  




### 📸: 실행 화면  


### 🚀: 조정 파일  
- lib/models/preference/preference_test_model.dart
- lib/repositories/preference/preference_test_repository.dart
- lib/services/preference/preference_test_service.dart
- lib/views/plan/plan/schedule/widgets/ai_button.dart
- lib/services/plan/place_search_service.dart
- lib/widgets/common/custom_toast.dart



### 개발 결과 요약  
- AI 추천받기 기능 플랜아이디당 3회로 제한 
- Kakao 장소 enrich 병렬 처리로 성능 개선  
- 성향 테스트 결과 캐싱 + 호출 제한 로직 성공적 적용  
- 사용자 경험(UX) 향상 및 API 비용 최적화  


### issue
Closes #256 
