### PR TITLE
[Post] 포스트 리스트 표시 버그 3종 픽스

### DIFF
--- a/lib/viewmodels/post/post_list_view_model.dart
+++ b/lib/viewmodels/post/post_list_view_model.dart
@@ -5,12 +5,13 @@ import 'package:travel_muse_app/models/post/post_list_state_model.dart';
 import 'package:travel_muse_app/models/post/post_model.dart';
 import 'package:travel_muse_app/repositories/post/post_list_repository.dart';
 
-class PostListViewModel extends AutoDisposeAsyncNotifier<PostListState> {
+class PostListViewModel
+    extends AutoDisposeAsyncNotifier<PostListState> {
   final _repository = PostListRepository();
 
   @override
   PostListState build() {
-    fetchInitialPosts();
+    refreshPosts();
     return PostListState();
   }
 
@@ -18,12 +19,16 @@ class PostListViewModel extends AutoDisposeAsyncNotifier<PostListState> {
     final currentState = state.value;
     if (currentState == null) return;
 
-    final exists = currentState.posts.any((p) => p.postId == post.postId);
+    final exists = currentState.posts.any(
+      (p) => p.postId == post.postId,
+    );
     if (exists) return;
 
-    final updatedPosts = [post, ...currentState.posts];
+    setFilterState(null);
 
-    state = AsyncData(currentState.copyWith(posts: updatedPosts));
+    // final updatedPosts = [post, ...currentState.posts];
+
+    // state = AsyncData(currentState.copyWith(posts: updatedPosts));
   }
 
   void updatePost(Post updatedPost) {
@@ -32,24 +37,38 @@ class PostListViewModel extends AutoDisposeAsyncNotifier<PostListState> {
 
     final updatedPosts =
         currentState.posts.map((post) {
-          return post.postId == updatedPost.postId ? updatedPost : post;
+          return post.postId == updatedPost.postId
+              ? updatedPost
+              : post;
         }).toList();
 
     state = AsyncData(currentState.copyWith(posts: updatedPosts));
   }
 
-  /// 포스트 리스트 초기값 상태 업데이트
+  /// 포스트 리스트 초기화 => filter=null
   Future<void> fetchInitialPosts() async {
     state = const AsyncLoading();
 
     try {
-      final filter = state.value?.filter;
-      final posts = await _repository.fetchInitialPosts(filter: filter);
-      final filteredPosts =
-          posts.where((post) => post.isDeleted == false).toList();
-      state = AsyncData(state.value!.copyWith(posts: filteredPosts));
+      final posts = await _repository.fetchInitialPosts(filter: null);
+      state = AsyncData(PostListState(posts: posts, filter: null));
     } catch (e) {
       log('포스트 리스트 초기값 가져오기 실패 : $e');
+    }
+  }
+
+  /// 포스트 리스트 새로고침
+  Future<void> refreshPosts() async {
+    state = const AsyncLoading();
+
+    try {
+      final filter = state.value?.filter;
+      final posts = await _repository.fetchInitialPosts(
+        filter: filter,
+      );
+      state = AsyncData(state.value!.copyWith(posts: posts));
+    } catch (e) {
+      log('포스트 리스트 새로고침 실패 : $e');
     }
   }
 
@@ -61,7 +80,9 @@ class PostListViewModel extends AutoDisposeAsyncNotifier<PostListState> {
       List<Post> newPosts;
 
       if (currentPosts.isEmpty) {
-        newPosts = await _repository.fetchInitialPosts(filter: filter);
+        newPosts = await _repository.fetchInitialPosts(
+          filter: filter,
+        );
       } else {
         final latestCreateAt = currentPosts.first.createAt;
         newPosts = await _repository.fetchNewPostsAfter(
@@ -69,7 +90,8 @@ class PostListViewModel extends AutoDisposeAsyncNotifier<PostListState> {
           filter: filter,
         );
 
-        final existingIds = currentPosts.map((post) => post.postId).toSet();
+        final existingIds =
+            currentPosts.map((post) => post.postId).toSet();
         newPosts =
             newPosts
                 .where((post) => !existingIds.contains(post.postId))
@@ -79,10 +101,10 @@ class PostListViewModel extends AutoDisposeAsyncNotifier<PostListState> {
       }
 
       // isDeleted 필드 기준으로 필터링
-      final filteredPosts =
-          newPosts.where((post) => post.isDeleted == false).toList();
+      // final filteredPosts =
+      //     newPosts.where((post) => post.isDeleted == false).toList();
 
-      state = AsyncData(state.value!.copyWith(posts: filteredPosts));
+      state = AsyncData(state.value!.copyWith(posts: newPosts));
     } catch (e) {
       log('당겨서 새로고침 실패 : $e');
     }
@@ -96,7 +118,9 @@ class PostListViewModel extends AutoDisposeAsyncNotifier<PostListState> {
       List<Post> newPosts;
 
       if (currentPosts.isEmpty) {
-        newPosts = await _repository.fetchInitialPosts(filter: filter);
+        newPosts = await _repository.fetchInitialPosts(
+          filter: filter,
+        );
       } else {
         final oldestCreateAt = currentPosts.last.createAt;
         newPosts = await _repository.fetchOldPostsBefore(
@@ -104,7 +128,8 @@ class PostListViewModel extends AutoDisposeAsyncNotifier<PostListState> {
           filter: filter,
         );
 
-        final existingIds = currentPosts.map((post) => post.postId).toSet();
+        final existingIds =
+            currentPosts.map((post) => post.postId).toSet();
         newPosts =
             newPosts
                 .where((post) => !existingIds.contains(post.postId))
@@ -112,37 +137,26 @@ class PostListViewModel extends AutoDisposeAsyncNotifier<PostListState> {
 
         newPosts = [...currentPosts, ...newPosts];
       }
-      final filteredPosts =
-          newPosts.where((post) => post.isDeleted == false).toList();
+      // final filteredPosts =
+      //     newPosts.where((post) => post.isDeleted == false).toList();
 
-      state = AsyncData(state.value!.copyWith(posts: filteredPosts));
+      state = AsyncData(state.value!.copyWith(posts: newPosts));
     } catch (e) {
       log('무한 스크롤 실패 : $e');
     }
   }
 
-  /// 필터 상태 업데이트
-  void setFilterState(String? filter) {
+  /// 필터 상태 업데이트 및 포스트 재로드
+  void setFilterState(String? filter) async {
     state = AsyncData(state.value!.copyWith(filter: filter));
-    filterPostsByTag(filter);
-  }
-
-  /// 현재 state의 posts 중 filter에 해당하는 태그가 있는 포스트만 남김
-  void filterPostsByTag(String? filter) {
-    final currentState = state.value;
-
-    if (currentState == null) return;
-
-    if (filter == null) {
-      state = AsyncData(currentState);
-      return;
+    try {
+      state = const AsyncLoading();
+      final posts = await _repository.fetchInitialPosts(
+        filter: filter,
+      );
+      state = AsyncData(PostListState(posts: posts, filter: filter));
+    } catch (e) {
+      log('필터 초기화 후 fetch 실패: $e');
     }
-
-    final filteredPosts =
-        currentState.posts.where((post) => post.tags.contains(filter)).toList();
-
-    state = AsyncData(
-      currentState.copyWith(posts: filteredPosts, filter: filter),
-    );
   }
 }

--- a/lib/views/post/post_detail_page.dart
+++ b/lib/views/post/post_detail_page.dart
@@ -8,6 +8,7 @@ import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/models/post/post_model.dart';
 import 'package:travel_muse_app/providers/post/like_provider.dart';
+import 'package:travel_muse_app/providers/post/post_list_view_model_provider.dart';
 import 'package:travel_muse_app/providers/post/post_provider.dart';
 import 'package:travel_muse_app/providers/scoial/report_provider.dart';
 import 'package:travel_muse_app/views/post/%08comment/comment_section.dart';
@@ -190,6 +191,12 @@ class _PostDetailPageState extends ConsumerState<PostDetailPage> {
                             await ref
                                 .read(postViewModelProvider.notifier)
                                 .deletePost(currentPost.postId);
+
+                            await ref
+                                .read(
+                                  postListViewModelProvider.notifier,
+                                )
+                                .fetchInitialPosts();
 
                             if (mounted) {
                               Navigator.pop(context, true);

--- a/lib/views/post/post_write_page.dart
+++ b/lib/views/post/post_write_page.dart
@@ -65,9 +65,9 @@ class _PostWritePageState extends ConsumerState<PostWritePage> {
     });
 
     if (addableFiles.length < pickedFiles.length) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text('최대 5장까지만 업로드할 수 있어요.')));
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('최대 5장까지만 업로드할 수 있어요.')),
+      );
     }
   }
 
@@ -78,8 +78,12 @@ class _PostWritePageState extends ConsumerState<PostWritePage> {
       );
       return;
     }
-    final titleError = PostValidator.validateTitle(titleController.text);
-    final contentError = PostValidator.validateContent(contentController.text);
+    final titleError = PostValidator.validateTitle(
+      titleController.text,
+    );
+    final contentError = PostValidator.validateContent(
+      contentController.text,
+    );
 
     if (titleError != null || contentError != null) {
       setState(() {
@@ -104,16 +108,16 @@ class _PostWritePageState extends ConsumerState<PostWritePage> {
       if (widget.post != null) {
         Navigator.pop(context, true); // 수정인 경우 → true 반환
         CustomToast.show(
-        context: context,
-        message: '게시물 수정이 완료되었습니다.',
-        duration: const Duration(seconds: 2),
-      );
+          context: context,
+          message: '게시물 수정이 완료되었습니다.',
+          duration: const Duration(seconds: 2),
+        );
       } else if (createdPost != null) {
         CustomToast.show(
-        context: context,
-        message: '게시물을 성공적으로 업로드했습니다.',
-        duration: const Duration(seconds: 2),
-      );
+          context: context,
+          message: '게시물을 성공적으로 업로드했습니다.',
+          duration: const Duration(seconds: 2),
+        );
         Navigator.pop(context, createdPost); // 새 글 작성인 경우 → post 반환
       }
     }
@@ -122,7 +126,8 @@ class _PostWritePageState extends ConsumerState<PostWritePage> {
   @override
   Widget build(BuildContext context) {
     final isWritable =
-        titleController.text.isNotEmpty || contentController.text.isNotEmpty;
+        titleController.text.isNotEmpty ||
+        contentController.text.isNotEmpty;
     final postState = ref.watch(postViewModelProvider);
     final isLoading = postState is AsyncLoading;
 
@@ -193,8 +198,10 @@ class _PostWritePageState extends ConsumerState<PostWritePage> {
                             title: selectedPlace!['title'] ?? '',
                             address: selectedPlace!['address'] ?? '',
                             latLng: LatLng(
-                              (selectedPlace!['lat'] as num).toDouble(),
-                              (selectedPlace!['lng'] as num).toDouble(),
+                              (selectedPlace!['lat'] as num)
+                                  .toDouble(),
+                              (selectedPlace!['lng'] as num)
+                                  .toDouble(),
                             ),
                           ),
                           Positioned(
@@ -226,16 +233,20 @@ class _PostWritePageState extends ConsumerState<PostWritePage> {
             ),
             PostLocationCategory(
               selectedTags: selectedTags,
-              onTagsChanged: (tags) => setState(() => selectedTags = tags),
+              onTagsChanged:
+                  (tags) => setState(() => selectedTags = tags),
               selectedPlace: selectedPlace,
-              onPlaceChanged: (place) => setState(() => selectedPlace = place),
+              onPlaceChanged:
+                  (place) => setState(() => selectedPlace = place),
             ),
             const SizedBox(height: 8),
             if (imagePaths.isNotEmpty) ...[
               const SizedBox(height: 12),
               ImagePreviewList(
                 imagePaths: imagePaths.take(5).toList(),
-                onRemove: (index) => setState(() => imagePaths.removeAt(index)),
+                onRemove:
+                    (index) =>
+                        setState(() => imagePaths.removeAt(index)),
               ),
             ],
             const SizedBox(height: 8),
@@ -251,4 +262,3 @@ class _PostWritePageState extends ConsumerState<PostWritePage> {
     );
   }
 }
-

--- a/lib/views/post/widgets/list/tag_bar.dart
+++ b/lib/views/post/widgets/list/tag_bar.dart
@@ -10,7 +10,8 @@ class TagBar extends ConsumerStatefulWidget {
   const TagBar({super.key});
 
   @override
-  ConsumerState<ConsumerStatefulWidget> createState() => _TagBarState();
+  ConsumerState<ConsumerStatefulWidget> createState() =>
+      _TagBarState();
 }
 
 class _TagBarState extends ConsumerState<TagBar> {
@@ -24,11 +25,17 @@ class _TagBarState extends ConsumerState<TagBar> {
 
     final reorderedTags =
         (selectedFilter != null && allTags.contains(selectedFilter))
-            ? [selectedFilter, ...allTags.where((tag) => tag != selectedFilter)]
+            ? [
+              selectedFilter,
+              ...allTags.where((tag) => tag != selectedFilter),
+            ]
             : allTags;
 
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.symmetric(
+        horizontal: 16,
+        vertical: 8,
+      ),
       child: Row(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -51,11 +58,16 @@ class _TagBarState extends ConsumerState<TagBar> {
                       ref
                           .read(postListViewModelProvider.notifier)
                           .setFilterState(newFilter);
-                      // ref.read(postListViewModelProvider.notifier).fetchFilteredPosts(tag);
+                      // ref
+                      //     .read(postListViewModelProvider.notifier)
+                      //     .filterPostsByTag(tag);
                     },
                     child: Container(
                       height: 30,
-                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 4,
+                      ),
                       decoration:
                           tag == selectedFilter
                               ? AppOtherStyles.selectedTag
@@ -72,7 +84,8 @@ class _TagBarState extends ConsumerState<TagBar> {
                     ),
                   );
                 },
-                separatorBuilder: (context, index) => SizedBox(width: 8),
+                separatorBuilder:
+                    (context, index) => SizedBox(width: 8),
               ),
             ),
           ),


### PR DESCRIPTION
### 🚀: 개요
- 포스트 리스트 표시 버그 3종 픽스

### 🚀: 작업 내용
- 포스트 리스트 페이지에서 태그 선택 후 다른 태그 선택 시 필터링 중첩되는 버그 픽스
- 태그 적용 후 포스트 등록 시 해당 태그 없는 새 포스트가 해당 태그 필터링에 포함되는 버그 픽스
- 포스트 삭제 시 태그만 해제되고 필터링 해제되지 않는 버그 픽스

### 📸: 실행 화면
<img src="https://github.com/user-attachments/assets/22408d8c-0c34-4948-a9f3-29e472ac5ca6" width="300" height="640"/>
<img src="https://github.com/user-attachments/assets/8cf6d3d9-be42-424c-ba7a-f2c1c057530f" width="300" height="640"/>

### 🚀: 조정 파일
- lib/viewmodels/post/post_list_view_model.dart
- lib/views/post/post_detail_page.dart
- lib/views/post/post_write_page.dart
- lib/views/post/widgets/list/tag_bar.dart

### 개발 결과
- 포스트 리스트 페이지에서 태그 선택 시마다 해당 태그로 필터링된 새 포스트 리스트 fetch
- 태그 적용 후 포스트 등록 시 태그 선택 해제하고 전체 포스트 리스트 새로 fetch
- 포스트 삭제 시 전체 포스트 리스트 새로 fetch

### issue
Closes #271
