### PR TITLE
[Preference]성향테스트 온보딩후 바텀 홈 클릭시 다시 성향테스트 인트로로 가는문제 수정

### DIFF
--- a/lib/core/widgets/bottom_bar.dart
+++ b/lib/core/widgets/bottom_bar.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/bottom_bar_provider.dart';
+import 'package:travel_muse_app/views/home/home_page.dart';
 import 'package:travel_muse_app/views/home/recommended_place/recommended_places_list_page.dart';
 import 'package:travel_muse_app/views/my_page/my_page.dart';
 import 'package:travel_muse_app/views/my_page/plan_list_page.dart';
@@ -23,7 +24,12 @@ class BottomBar extends ConsumerWidget {
       Widget page;
       switch (index) {
         case 0:
-          Navigator.of(context).popUntil((route) => route.isFirst);
+          Navigator.pushAndRemoveUntil(
+            context,
+            MaterialPageRoute(builder: (_) => const HomePage()),
+            (route) => false,
+          );
+          // Navigator.of(context).popUntil((route) => route.isFirst);
           return;
         case 1:
           page = const PlanListPage();


### PR DESCRIPTION
### 🚀: 개요
- 성향테스트 온보딩후 바텀 홈 클릭시 다시 성향테스트 인트로로 가는문제 수정

### 🚀: 작업 내용
- 성향테스트 온보딩후 바텀 홈 클릭시 다시 성향테스트 인트로로 가는문제 수정


### 📸: 실행 화면
### 📸: 실행 화면


### 🚀: 조정 파일
- bottom_bar

### 개발 결과
- 성향테스트 온보딩후 바텀 홈 클릭시 다시 성향테스트 인트로로 가는문제 수정

### issue
Closes #270 
