### PR TITLE
[Post]실시간 댓글수 답글까지 수정 완료

### DIFF
--- a/lib/repositories/post/comment_repository.dart
+++ b/lib/repositories/post/comment_repository.dart
@@ -64,14 +64,26 @@ class CommentRepository {
   Future<void> deleteComment(String postId, String commentId) async {
     final postRef = _firestore.collection('posts').doc(postId);
     final commentRef = getCommentsRef(postId).doc(commentId);
+    final repliesQuery =
+        await getCommentsRef(
+          postId,
+        ).where('parentId', isEqualTo: commentId).get();
+
+    final totalDeleteCount = 1 + repliesQuery.docs.length;
 
     await _firestore.runTransaction((txn) async {
       final postSnap = await txn.get(postRef);
+      final currentCount = (postSnap.data()?['commentCount'] ?? 0) as int;
 
-      final currentCount = (postSnap.data()?['commentCount'] ?? 1) as int;
-
+      // 원댓글 삭제
       txn.delete(commentRef);
-      txn.update(postRef, {'commentCount': currentCount - 1});
+
+      // 답글들 삭제
+      for (final doc in repliesQuery.docs) {
+        txn.delete(doc.reference);
+      }
+
+      txn.update(postRef, {'commentCount': currentCount - totalDeleteCount});
     });
   }
 

--- a/lib/views/post/comment/comment_section.dart
+++ b/lib/views/post/comment/comment_section.dart
@@ -23,9 +23,12 @@ class CommentSection extends ConsumerWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        FutureBuilder<DocumentSnapshot>(
-          future:
-              FirebaseFirestore.instance.collection('posts').doc(postId).get(),
+        StreamBuilder<DocumentSnapshot>(
+          stream:
+              FirebaseFirestore.instance
+                  .collection('posts')
+                  .doc(postId)
+                  .snapshots(),
           builder: (context, snapshot) {
             if (!snapshot.hasData || !snapshot.data!.exists)
               return const SizedBox();
@@ -104,10 +107,7 @@ class CommentSection extends ConsumerWidget {
                     createdAt: Timestamp.now(),
                   );
                   viewModel.addComment(comment);
-                  FirebaseFirestore.instance
-                      .collection('posts')
-                      .doc(postId)
-                      .update({'commentCount': FieldValue.increment(1)});
+
                   controller.clear();
                   onCommentAdded?.call();
                 },


### PR DESCRIPTION
### 🚀: 개요
- 실시간 댓글수 답글까지 수정 완료
- commentCount 필드 정확히 반영되도록 수정

### 🚀: 작업 내용
- CommentRepository.deleteComment 메서드 수정
- 댓글 삭제 시 해당 댓글의 답글도 함께 삭제되도록 처리
- 삭제된 댓글 + 답글 개수를 commentCount에서 차감하도록 트랜잭션 적용
- 댓글 개수 UI와 실 데이터 간 싱크 맞춤
- ex) 위젯 분리

### 📸: 실행 화면
### 📸: 실행 화면


### 🚀: 조정 파일
- lib/repositories/post/comment_repository.dart

### 개발 결과
- 댓글 삭제 시 답글도 함께 삭제되며, 댓글 수(commentCount)가 정확히 갱신됨
- 댓글이 1개, 답글 2개 → 댓글 삭제 시 count가 -3 되는 것 확인됨
- 리스트/상세페이지 모두 실시간 반영 확인 완료

### issue
Closes #278 
