### PR TITLE
[Plan] 카카오 API 429 오류 해결 

### DIFF
--- a/lib/services/plan/place_search_service.dart
+++ b/lib/services/plan/place_search_service.dart
@@ -23,18 +23,23 @@ class _CacheItem<T> {
 //   capacity 만큼 토큰을 들고 시작 -> period(1초)마다 재충전
 //   take() 호출로 토큰 확보, 없으면 대기큐에 들어감
 class _RateLimiter {
-  _RateLimiter(this.capacity, this.period) // 최초 토큰량 = capacity
-    : _tokens = capacity,
-      _last = DateTime.now();
-  final int capacity; // 버킷 크기 (5)
-  final Duration period; // 리필 주기 (1초)
+  _RateLimiter(this.capacity, this.period)
+      : _tokens = capacity,
+        _last = DateTime.now() {
+    _timer = Timer.periodic(period, (_) => _refill());
+  }
 
-  int _tokens; // 남은 토큰 수
-  DateTime _last; // 마지막 리필 시각
-  final _queue = <Completer<void>>[]; // 대기
+  final int capacity;          
+  final Duration period;      
+
+  int _tokens;
+  DateTime _last;
+  final _queue = <Completer<void>>[];
+
+  late final Timer _timer;     
+  void dispose() => _timer.cancel();
 
   Future<void> take() {
-    _refill();
     final c = Completer<void>();
     if (_tokens > 0) {
       _tokens--;
@@ -45,19 +50,17 @@ class _RateLimiter {
     return c.future;
   }
 
-  /// 토큰 재충전 + 대기 해제
+  ///타이머에서 호출 ― 토큰 충전 & 대기열 해제
   void _refill() {
-    final now = DateTime.now();
-    if (now.difference(_last) >= period) {
-      _tokens = capacity;
-      _last = now;
-      while (_tokens > 0 && _queue.isNotEmpty) {
-        _tokens--;
-        _queue.removeAt(0).complete();
-      }
+    _tokens = capacity;
+    _last = DateTime.now();
+    while (_tokens > 0 && _queue.isNotEmpty) {
+      _tokens--;
+      _queue.removeAt(0).complete();
     }
   }
 }
+
 
 class PlaceSearchService {
   static const _baseKeywordUrl =
@@ -149,9 +152,12 @@ class PlaceSearchService {
   }
 
   /// 썸네일(키워드당 1장) 캐시
-  final Map<String, String> _thumbCache = {}; // keyword -> url
+  static final _thumbCache =
+    quiver.LruMap<String, _CacheItem<String>>(maximumSize: 1000);
 
+  ///썸네일
   Future<String?> fetchImageThumbnail(String keyword) async {
+    await _limiter.take(); 
     final url = Uri.parse(
       '$_baseImageUrl?query=${Uri.encodeQueryComponent(keyword)}&size=1',
     );
@@ -174,11 +180,13 @@ class PlaceSearchService {
   }
 
   Future<String?> getThumbnailCached(String keyword) async {
-    if (_thumbCache.containsKey(keyword)) return _thumbCache[keyword];
-    final url = await fetchImageThumbnail(keyword);
-    if (url != null) _thumbCache[keyword] = url;
-    return url;
-  }
+  final cached = _thumbCache[keyword];
+  if (cached != null && !_isExpired(cached.createdAt)) return cached.value;
+
+  final url = await fetchImageThumbnail(keyword);
+  if (url != null) _thumbCache[keyword] = _CacheItem(url);   
+  return url;
+}
 
   /// 주소 -> 좌표 변환
   Future<LatLng?> getLatLngFromRegion(String region) async {

--- a/lib/services/plan/place_search_service.dart
+++ b/lib/services/plan/place_search_service.dart
@@ -123,34 +123,47 @@ class PlaceSearchService {
 
   /// 내부 공통 로직: 캐시 -> 리미트 -> 네트워크
   Future<List<Place>> _requestPlaces(Uri url) async {
-    final key = url.toString();
-    final cached = _searchCache[key];
-    if (cached != null && !_isExpired(cached.createdAt)) return cached.value;
+  final key = url.toString();
 
-    await _limiter.take();
-    try {
-      final res = await http.get(
-        url,
-        headers: {'Authorization': _apiKey, 'User-Agent': 'TravelMuse/1.0'},
-      );
-      if (res.statusCode == 429) {
-        debugPrint('Kakao 429 Too Many Requests → ${url.path}');
-        return [];
-      }
-      if (res.statusCode != 200) {
-        throw Exception('Kakao API 실패: ${res.statusCode}');
-      }
-      final docs =
-          (json.decode(res.body)['documents'] as List<dynamic>)
-              .map((e) => Place.fromKakaoJson(e))
-              .toList();
-      _searchCache[key] = _CacheItem(docs);
-      return docs;
-    } catch (e) {
-      debugPrint('Kakao 요청 오류: $e');
+  // 캐시 확인
+  final cached = _searchCache[key];
+  if (cached != null && !_isExpired(cached.createdAt)) return cached.value;
+
+  // 레이트리미터 통과
+  await _limiter.take();
+
+  try {
+    // 카카오 API 호출
+    final res = await http.get(
+      url,
+      headers: {'Authorization': _apiKey, 'User-Agent': 'TravelMuse/1.0'},
+    );
+
+    // 429 또는 오류 처리
+    if (res.statusCode == 429) {
+      debugPrint('Kakao 429 Too Many Requests → ${url.path}');
       return [];
     }
+    if (res.statusCode != 200) {
+      throw Exception('Kakao API 실패: ${res.statusCode}');
+    }
+
+    // 결과 파싱
+    final docs = (json.decode(res.body)['documents'] as List<dynamic>)
+        .map((e) => Place.fromKakaoJson(e))
+        .toList();
+
+    // 결과가 있을 때만 캐시
+    if (docs.isNotEmpty) {
+      _searchCache[key] = _CacheItem(docs);
+    }
+
+    return docs;
+  } catch (e) {
+    debugPrint('Kakao 요청 오류: $e');
+    return [];
   }
+}
 
   /// 썸네일(키워드당 1장) 캐시
   static final _thumbCache =
@@ -177,7 +190,7 @@ class PlaceSearchService {
         final docs = json.decode(res.body)['documents'] as List<dynamic>;
         return docs.isNotEmpty ? docs[0]['thumbnail_url'] as String : null;
       }
-      if (res.statusCode == 429) return null; // 그대로 처리
+      if (res.statusCode == 429) return null; 
     } on HttpException catch (e) {
       debugPrint('썸네일 재시도 $attempt: $e');
       await Future.delayed(const Duration(milliseconds: 100));

--- a/lib/services/plan/place_search_service.dart
+++ b/lib/services/plan/place_search_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -156,28 +157,35 @@ class PlaceSearchService {
     quiver.LruMap<String, _CacheItem<String>>(maximumSize: 1000);
 
   ///썸네일
-  Future<String?> fetchImageThumbnail(String keyword) async {
-    await _limiter.take(); 
-    final url = Uri.parse(
-      '$_baseImageUrl?query=${Uri.encodeQueryComponent(keyword)}&size=1',
-    );
+ Future<String?> fetchImageThumbnail(String keyword) async {
+  await _limiter.take();
+  final url = Uri.parse(
+    '$_baseImageUrl?query=${Uri.encodeQueryComponent(keyword)}&size=1',
+  );
+
+  for (var attempt = 0; attempt < 3; attempt++) {
     try {
       final res = await http.get(
         url,
-        headers: {'Authorization': _apiKey, 'User-Agent': 'TravelMuse/1.0'},
+        headers: {
+          'Authorization': _apiKey,
+          'User-Agent': 'TravelMuse/1.0',
+          'Connection': 'close'         
+        },
       );
-      if (res.statusCode == 429) {
-        debugPrint('Kakao 이미지 429: $keyword');
-        return null;
+      if (res.statusCode == 200) {
+        final docs = json.decode(res.body)['documents'] as List<dynamic>;
+        return docs.isNotEmpty ? docs[0]['thumbnail_url'] as String : null;
       }
-      if (res.statusCode != 200) return null;
-      final docs = json.decode(res.body)['documents'] as List<dynamic>;
-      return docs.isNotEmpty ? docs[0]['thumbnail_url'] as String : null;
-    } catch (e) {
-      debugPrint('썸네일 요청 실패: $e');
-      return null;
+      if (res.statusCode == 429) return null; // 그대로 처리
+    } on HttpException catch (e) {
+      debugPrint('썸네일 재시도 $attempt: $e');
+      await Future.delayed(const Duration(milliseconds: 100));
     }
   }
+  return null; // 3회 실패
+}
+
 
   Future<String?> getThumbnailCached(String keyword) async {
   final cached = _thumbCache[keyword];

--- a/lib/services/plan/place_search_service.dart
+++ b/lib/services/plan/place_search_service.dart
@@ -1,15 +1,65 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:http/http.dart' as http;
+import 'package:quiver/collection.dart' as quiver;
 import 'package:travel_muse_app/models/plan/place.dart';
 import 'package:travel_muse_app/providers/plan/schedule/recent_search_provider.dart';
 import 'package:travel_muse_app/providers/plan/schedule/search_provider.dart';
 
+/// 캐시용 래퍼 클래스
+//   - value: 실제 캐싱 데이터
+//   - createdAt: 삽입 시각 (TTL 판정용)
+class _CacheItem<T> {
+  _CacheItem(this.value) : createdAt = DateTime.now();
+  final T value;
+  final DateTime createdAt;
+}
+
+/// 간단 토큰 버킷(rate‑limit) 구현
+//   capacity 만큼 토큰을 들고 시작 -> period(1초)마다 재충전
+//   take() 호출로 토큰 확보, 없으면 대기큐에 들어감
+class _RateLimiter {
+  _RateLimiter(this.capacity, this.period) // 최초 토큰량 = capacity
+    : _tokens = capacity,
+      _last = DateTime.now();
+  final int capacity; // 버킷 크기 (5)
+  final Duration period; // 리필 주기 (1초)
+
+  int _tokens; // 남은 토큰 수
+  DateTime _last; // 마지막 리필 시각
+  final _queue = <Completer<void>>[]; // 대기
+
+  Future<void> take() {
+    _refill();
+    final c = Completer<void>();
+    if (_tokens > 0) {
+      _tokens--;
+      c.complete();
+    } else {
+      _queue.add(c);
+    }
+    return c.future;
+  }
+
+  /// 토큰 재충전 + 대기 해제
+  void _refill() {
+    final now = DateTime.now();
+    if (now.difference(_last) >= period) {
+      _tokens = capacity;
+      _last = now;
+      while (_tokens > 0 && _queue.isNotEmpty) {
+        _tokens--;
+        _queue.removeAt(0).complete();
+      }
+    }
+  }
+}
+
 class PlaceSearchService {
-  //API 기본 값
   static const _baseKeywordUrl =
       'https://dapi.kakao.com/v2/local/search/keyword.json';
   static const _baseCategoryUrl =
@@ -17,7 +67,19 @@ class PlaceSearchService {
   static const _baseImageUrl = 'https://dapi.kakao.com/v2/search/image';
   static final String _apiKey = 'KakaoAK ${dotenv.env['KAKAO_API_KEY'] ?? ''}';
 
-  ///키워드 검색
+  static final _searchCache = quiver.LruMap<String, _CacheItem<List<Place>>>(
+    maximumSize: 500,
+  );
+  static final _addrCache = quiver.LruMap<String, _CacheItem<LatLng?>>(
+    maximumSize: 500,
+  );
+  static const _cacheTTL = Duration(hours: 24);
+  static bool _isExpired(DateTime t) =>
+      DateTime.now().difference(t) > _cacheTTL;
+
+  static final _limiter = _RateLimiter(5, const Duration(seconds: 1));
+
+  /// 위치 상관없는 키워드 검색
   Future<List<Place>> search(String query) async {
     final url = Uri.parse(
       '$_baseKeywordUrl?query=${Uri.encodeQueryComponent(query)}',
@@ -25,7 +87,7 @@ class PlaceSearchService {
     return _requestPlaces(url);
   }
 
-  ///키워드 + 위치
+  /// 내 위치 기준 키워드 검색
   Future<List<Place>> searchByKeyword({
     required String query,
     required double lat,
@@ -35,15 +97,12 @@ class PlaceSearchService {
     int size = 15,
   }) async {
     final url = Uri.parse(
-      '$_baseKeywordUrl'
-      '?query=${Uri.encodeQueryComponent(query)}'
-      '&y=$lat&x=$lng'
-      '&radius=$radius&page=$page&size=$size&sort=distance',
+      '$_baseKeywordUrl?query=${Uri.encodeQueryComponent(query)}&y=$lat&x=$lng&radius=$radius&page=$page&size=$size&sort=distance',
     );
     return _requestPlaces(url);
   }
 
-  ///카테고리 + 위치
+  /// 카테고리(AT4, FD6 등) 검색
   Future<List<Place>> searchByCategory({
     required String categoryCode,
     required double lat,
@@ -53,43 +112,45 @@ class PlaceSearchService {
     int size = 15,
   }) async {
     final url = Uri.parse(
-      '$_baseCategoryUrl'
-      '?category_group_code=$categoryCode'
-      '&y=$lat&x=$lng'
-      '&radius=$radius&page=$page&size=$size&sort=distance',
+      '$_baseCategoryUrl?category_group_code=$categoryCode&y=$lat&x=$lng&radius=$radius&page=$page&size=$size&sort=distance',
     );
     return _requestPlaces(url);
   }
 
-  ///공통 HTTP 처리
+  /// 내부 공통 로직: 캐시 -> 리미트 -> 네트워크
   Future<List<Place>> _requestPlaces(Uri url) async {
+    final key = url.toString();
+    final cached = _searchCache[key];
+    if (cached != null && !_isExpired(cached.createdAt)) return cached.value;
+
+    await _limiter.take();
     try {
       final res = await http.get(
         url,
-        headers: {'Authorization': _apiKey, 'User-Agent': 'Mozilla/5.0'},
+        headers: {'Authorization': _apiKey, 'User-Agent': 'TravelMuse/1.0'},
       );
-
-      // 429: Too Many Requests → 앱 크래시 방지, 빈 리스트 반환
       if (res.statusCode == 429) {
-        debugPrint(
-          'Kakao 429 Too Many Requests: ${url.queryParameters['query']}',
-        );
+        debugPrint('Kakao 429 Too Many Requests → ${url.path}');
         return [];
       }
-
       if (res.statusCode != 200) {
         throw Exception('Kakao API 실패: ${res.statusCode}');
       }
-
-      final docs = json.decode(res.body)['documents'] as List<dynamic>;
-      return docs.map((e) => Place.fromKakaoJson(e)).toList();
+      final docs =
+          (json.decode(res.body)['documents'] as List<dynamic>)
+              .map((e) => Place.fromKakaoJson(e))
+              .toList();
+      _searchCache[key] = _CacheItem(docs);
+      return docs;
     } catch (e) {
       debugPrint('Kakao 요청 오류: $e');
       return [];
     }
   }
 
-  ///이미지 썸네일 직접호출
+  /// 썸네일(키워드당 1장) 캐시
+  final Map<String, String> _thumbCache = {}; // keyword -> url
+
   Future<String?> fetchImageThumbnail(String keyword) async {
     final url = Uri.parse(
       '$_baseImageUrl?query=${Uri.encodeQueryComponent(keyword)}&size=1',
@@ -97,7 +158,7 @@ class PlaceSearchService {
     try {
       final res = await http.get(
         url,
-        headers: {'Authorization': _apiKey, 'User-Agent': 'Mozilla/5.0'},
+        headers: {'Authorization': _apiKey, 'User-Agent': 'TravelMuse/1.0'},
       );
       if (res.statusCode == 429) {
         debugPrint('Kakao 이미지 429: $keyword');
@@ -112,56 +173,51 @@ class PlaceSearchService {
     }
   }
 
-  ///썸네일 캐싱
-  final Map<String, String> _thumbCache = {}; // keyword -> url
-
   Future<String?> getThumbnailCached(String keyword) async {
     if (_thumbCache.containsKey(keyword)) return _thumbCache[keyword];
-
     final url = await fetchImageThumbnail(keyword);
     if (url != null) _thumbCache[keyword] = url;
     return url;
   }
 
-  ///주소 좌표 변환
+  /// 주소 -> 좌표 변환
   Future<LatLng?> getLatLngFromRegion(String region) async {
+    final key = 'addr:$region';
+    final cached = _addrCache[key];
+    if (cached != null && !_isExpired(cached.createdAt)) return cached.value;
+
+    await _limiter.take();
     final url = Uri.parse(
-      'https://dapi.kakao.com/v2/local/search/address.json'
-      '?query=${Uri.encodeQueryComponent(region)}',
+      'https://dapi.kakao.com/v2/local/search/address.json?query=${Uri.encodeQueryComponent(region)}',
     );
     try {
       final res = await http.get(
         url,
-        headers: {'Authorization': _apiKey, 'User-Agent': 'Mozilla/5.0'},
+        headers: {'Authorization': _apiKey, 'User-Agent': 'TravelMuse/1.0'},
       );
-
       if (res.statusCode == 429) {
-        debugPrint('Kakao 주소→좌표 429: $region');
+        debugPrint('Kakao 주소->좌표 429: $region');
         return null;
       }
       if (res.statusCode != 200) return null;
-
       final docs = json.decode(res.body)['documents'] as List<dynamic>;
       if (docs.isEmpty) return null;
-
       final lat = double.tryParse(docs[0]['y']) ?? 0;
       final lng = double.tryParse(docs[0]['x']) ?? 0;
-      return LatLng(lat, lng);
+      final coord = LatLng(lat, lng);
+      _addrCache[key] = _CacheItem(coord);
+      return coord;
     } catch (e) {
-      debugPrint('주소→좌표 실패: $e');
+      debugPrint('주소->좌표 실패: $e');
       return null;
     }
   }
 
-  /// 실제 검색 실행 + 최근 검색어 저장
+  ///최근 검색어 저장
   static void performSearch(WidgetRef ref, String region, String query) {
     final trimmed = query.trim();
     if (trimmed.isEmpty) return;
-
-    // 최근 검색어 저장
     ref.read(recentSearchProvider.notifier).add(trimmed);
-
-    // 검색 API 호출
     ref.read(searchViewModelProvider.notifier).search(trimmed, region: region);
   }
 }

--- a/lib/utills/debouncer.dart
+++ b/lib/utills/debouncer.dart
@@ -1,0 +1,16 @@
+import 'dart:async';
+
+/// 입력 호출을 잠시 대기시켜
+/// 같은 작업이 짧은 시간 안에 연속으로 실행되는 걸 막아준다
+class Debouncer {
+  Debouncer(this.delay);
+  final Duration delay;
+  Timer? _timer;
+
+  void run(void Function() action) {
+    _timer?.cancel();          // 직전 타이머 취소
+    _timer = Timer(delay, action);
+  }
+
+  void dispose() => _timer?.cancel();
+}

--- a/lib/views/plan/plan/place_search/place_search_page.dart
+++ b/lib/views/plan/plan/place_search/place_search_page.dart
@@ -54,9 +54,9 @@ class _PlaceSearchPageState extends ConsumerState<PlaceSearchPage> {
   @override
   void initState() {
     super.initState();
-     WidgetsBinding.instance.addPostFrameCallback((_) {
-    ref.read(selectedIndexProvider.notifier).clear();
-  });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      ref.read(selectedIndexProvider.notifier).clear();
+    });
 
     _loadRecommendedPlacesByRegion();
   }
@@ -83,8 +83,9 @@ class _PlaceSearchPageState extends ConsumerState<PlaceSearchPage> {
               padding: const EdgeInsets.all(16),
               child: SearchBar(
                 controller: _searchController,
-                onSearch: () => _handleSearch(_searchController.text),
-                onSubmitted: _handleSearch,
+                onSearch:
+                    () => _handleSearch(_searchController.text), 
+                onQueryChanged: _handleSearch,
               ),
             ),
             RecentSearchSection(

--- a/lib/views/plan/plan/place_search/widgets/search_bar.dart
+++ b/lib/views/plan/plan/place_search/widgets/search_bar.dart
@@ -1,48 +1,75 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/utills/debouncer.dart';
 
-class SearchBar extends StatelessWidget {
+class SearchBar extends StatefulWidget {
   const SearchBar({
     super.key,
     required this.controller,
     required this.onSearch,
-    required this.onSubmitted,
+    required this.onQueryChanged,
   });
 
   final TextEditingController controller;
   final VoidCallback onSearch;
-  final Function(String) onSubmitted;
+  final ValueChanged<String> onQueryChanged;
+
+  @override
+  State<SearchBar> createState() => _SearchBarState();
+}
+
+class _SearchBarState extends State<SearchBar> {
+  late final Debouncer _debouncer;
+
+  @override
+  void initState() {
+    super.initState();
+    _debouncer = Debouncer(const Duration(milliseconds: 300));
+  }
+
+  @override
+  void dispose() {
+    _debouncer.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8), 
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       decoration: BoxDecoration(
-        color: AppColors.grey[50],               
-        borderRadius: BorderRadius.circular(28), 
+        color: AppColors.grey[50],
+        borderRadius: BorderRadius.circular(28),
       ),
       child: Row(
         children: [
           GestureDetector(
-            onTap: onSearch,
+            onTap: widget.onSearch,
             behavior: HitTestBehavior.opaque,
-            child: SvgPicture.asset('assets/icons/search.svg', 
-                  width: 28,
-                  height: 28,),
+            child: SvgPicture.asset(
+              'assets/icons/search.svg',
+              width: 28,
+              height: 28,
+            ),
           ),
           const SizedBox(width: 8),
           Expanded(
             child: TextField(
-              controller: controller,
-              onSubmitted: onSubmitted,
+              controller: widget.controller,
+              onChanged: (q) => _debouncer.run(() {
+                final trimmed = q.trim();
+                if (trimmed.length < 2) return; 
+                widget.onQueryChanged(trimmed);
+              }),
+              onSubmitted: (q) => widget.onQueryChanged(q.trim()), 
               style: const TextStyle(
                 fontSize: 16,
                 fontFamily: 'Pretendard',
                 fontWeight: FontWeight.w400,
               ),
-              decoration:  InputDecoration(
-                isCollapsed: true,                
+              decoration: InputDecoration(
+                isCollapsed: true,
                 hintText: '검색어를 입력해주세요',
                 hintStyle: TextStyle(
                   color: AppColors.grey[400],
@@ -59,4 +86,3 @@ class SearchBar extends StatelessWidget {
     );
   }
 }
-

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,8 @@ dependencies:
   image: ^4.5.4
   webview_flutter: ^4.13.0
   cloud_functions: ^5.5.2
+  collection: ^1.19.1
+  quiver: ^3.2.2
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### 🚀: 개요
- 카카오 API 429 오류를 근본적으로 줄이기 위해 클라이언트 레이어 최적화(디바운스) 도입
- 서비스 레이어 캐싱 & 레이트리미터를 도입

### 🚀: 작업 내용
- Debouncer 유틸 추가
- 300 ms 지연 + 2글자 이상 조건으로 자동 호출 제어
- SearchBar 위젯 리팩토링
- 디바운스 적용, 돋보기,엔터 검색 분리
- PlaceSearchService 강화
- quiver.LruMap(500, TTL 24 h) 도입
- RateLimiter(5 req/s) 추가
- 세션 메모리 Map 캐시 및 LRU·TTL 적용
- quiver 의존성 추가

### 🚀: 조정 파일
- pubspec.yaml
- debouncer.dart
- place_search_service.dart
- search_bar.dart
- place_search_page.dart

### 개발 결과
- 단일 사용자 QPS 15 -> ≤ 5
- 검색 체감 속도 즉시 호출 -> 300 ms 안정 응답
- 메모리 사용(캐시) 0 -> 0.5 MB



### issue
Closes #277 
