### PR TITLE
[location] 지도 페이지 성능이슈 해결

### DIFF
--- a/lib/views/plan/location/map_page.dart
+++ b/lib/views/plan/location/map_page.dart
@@ -17,7 +17,8 @@ class MapPage extends ConsumerStatefulWidget {
   ConsumerState<MapPage> createState() => _MapPageState();
 }
 
-class _MapPageState extends ConsumerState<MapPage> with TickerProviderStateMixin {
+class _MapPageState extends ConsumerState<MapPage>
+    with TickerProviderStateMixin {
   GoogleMapController? _mapController;
   bool _cameraMoved = false;
   LatLng _initialLatLng = const LatLng(37.5665, 126.9780);
@@ -31,19 +32,14 @@ class _MapPageState extends ConsumerState<MapPage> with TickerProviderStateMixin
     if (!_tabController!.indexIsChanging) {
       setState(() {});
       final index = _tabController!.index;
-      if (index == 0) {
-        final allPlaces = _viewModel.getAllPlaces();
-        _viewModel.moveCameraToFitAll(_mapController, allPlaces);
-      } else {
-        final newPlaces = mapState.dayPlaces[dayKeys[_tabController!.index - 1]] ?? [];
-        _viewModel.moveCameraToFitAll(_mapController, newPlaces);
-      }
+      final newPlaces = mapState.dayPlaces[dayKeys[index]] ?? [];
+      _viewModel.moveCameraToFitAll(_mapController, newPlaces);
     }
   }
 
   bool _isLoading(TabController? tabController, List<String> dayKeys) {
     if (tabController == null || dayKeys.isEmpty) return true;
-    if (tabController.index >= dayKeys.length + 1) return true;
+    if (tabController.index >= dayKeys.length) return true;
     return false;
   }
 
@@ -52,7 +48,7 @@ class _MapPageState extends ConsumerState<MapPage> with TickerProviderStateMixin
     await _viewModel.loadPlanAndRoute(widget.planId, this);
     final dayKeys = ref.read(mapViewModelProvider).dayPlaces.keys.toList();
     if (dayKeys.isEmpty) return;
-    _tabController = TabController(length: dayKeys.length + 1, vsync: this);
+    _tabController = TabController(length: dayKeys.length, vsync: this);
     _tabController!.addListener(_onTabChanged);
     setState(() {});
   }
@@ -97,16 +93,13 @@ class _MapPageState extends ConsumerState<MapPage> with TickerProviderStateMixin
     }
     final index = _tabController!.index;
     List<Map<String, dynamic>> selectedPlaces;
-    if (index == 0) {
-      selectedPlaces = _viewModel.getAllPlaces();
-    } else {
-      selectedPlaces = mapState.dayPlaces[dayKeys[index - 1]] ?? [];
-    }
+    selectedPlaces = mapState.dayPlaces[dayKeys[index]] ?? [];
+
     _initCameraPosition(selectedPlaces);
     final points = _viewModel.extractLatLngs(selectedPlaces);
     final markers = _viewModel.getMarkers(
       places: selectedPlaces,
-      selectedDayKey: index == 0 ? 'all' : dayKeys[index - 1],
+      selectedDayKey: dayKeys[index],
       onTap: (place) => _viewModel.selectPlace(place),
       onPageChanged: (index) {
         if (!_tabController!.indexIsChanging) {
@@ -114,7 +107,8 @@ class _MapPageState extends ConsumerState<MapPage> with TickerProviderStateMixin
         }
       },
     );
-    final displayDayTabs = ['All', ...dayKeys.map(getDisplayDayTab)];
+    final displayDayTabs = dayKeys.map(getDisplayDayTab).toList();
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('지도'),
@@ -131,7 +125,10 @@ class _MapPageState extends ConsumerState<MapPage> with TickerProviderStateMixin
                 _mapController = controller;
                 if (!_cameraMoved && selectedPlaces.isNotEmpty) {
                   Future.delayed(const Duration(milliseconds: 300), () {
-                    _viewModel.moveCameraToFitAll(_mapController, selectedPlaces);
+                    _viewModel.moveCameraToFitAll(
+                      _mapController,
+                      selectedPlaces,
+                    );
                     _cameraMoved = true;
                   });
                 }
@@ -163,3 +160,4 @@ class _MapPageState extends ConsumerState<MapPage> with TickerProviderStateMixin
     );
   }
 }
+

--- a/lib/views/plan/location/widgets/place_carousel.dart
+++ b/lib/views/plan/location/widgets/place_carousel.dart
@@ -29,41 +29,9 @@ class PlaceCarousel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final allPlaces = viewModel.getAllPlaces();
-    final allController = viewModel.getPageController('all');
-
     return TabBarView(
       controller: tabController,
       children: [
-        PageView.builder(
-          itemCount: allPlaces.length,
-          controller: allController,
-          onPageChanged: (index) {
-            final place = allPlaces[index];
-            final latLng = parseLatLng(place);
-            if (latLng != null) {
-              mapController?.animateCamera(
-                CameraUpdate.newLatLngZoom(latLng, 14),
-              );
-            }
-            viewModel.selectPlace(place);
-          },
-          itemBuilder: (context, index) {
-            final place = allPlaces[index];
-            return Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 8.0,
-                vertical: 12,
-              ),
-              child: PlaceCard(
-                placeData: place,
-                isSelected: selectedPlace?['id'] == place['id'],
-                isSelectMode: isSelectMode,
-              ),
-            );
-          },
-        ),
-
         for (final day in dayKeys)
           Builder(
             builder: (context) {
@@ -116,3 +84,4 @@ class PlaceCarousel extends StatelessWidget {
     );
   }
 }
+

--- a/lib/views/plan/plan/widgets/schedule_app_bar.dart
+++ b/lib/views/plan/plan/widgets/schedule_app_bar.dart
@@ -4,7 +4,6 @@ import 'package:flutter_svg/svg.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/providers/plan/schedule/schedule_provider.dart';
-import 'package:travel_muse_app/utills/date_utils.dart';
 import 'package:travel_muse_app/views/plan/location/map_page.dart';
 import 'package:travel_muse_app/views/plan/plan/schedule/widgets/schedule_confirm_dialog.dart';
 
@@ -86,11 +85,11 @@ class ScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
                   .read(scheduleViewModelProvider.notifier)
                   .getTripDays(planId);
 
-              if (tripDays >= 5) {
+              if (tripDays >= 10) {
                 if (context.mounted) {
                   CustomToast.show(
                     context: context,
-                    message: '5일 이상 일정은 지도로 확인할 수 없어요.',
+                    message: '10일 이상 일정은 지도로 확인할 수 없어요.',
                     duration: const Duration(seconds: 2),
                   );
                 }
@@ -115,3 +114,4 @@ class ScheduleAppBar extends ConsumerWidget implements PreferredSizeWidget {
   @override
   Size get preferredSize => const Size.fromHeight(kToolbarHeight);
 }
+


### PR DESCRIPTION
Fixes #283 refactor : 전체탭 제거

### 🚀: 개요
- 메모리 부족 문제로 인한 지도 페이지 성능이슈 해결

### 🚀: 작업 내용
- MapPage에서 일정 전체보기("All") 탭 제거
- 일정 수가 많아졌을 때 지도 진입 시 앱이 종료되는 이슈 대응
- TabController, TabBarView, PlaceCarousel에서 "All" 관련 코드 제거 및 정리

### 🚀: 조정 파일
- map_page
- map_carousel
- day_tab_bar
- schedule_page

### 개발 결과
- All 탭 제거 후 지도 진입 시 앱 종료 현상 사라짐
- 일정 수에 따라 발생하던 성능 저하 개선

### issue
Closes #283 
