### PR TITLE
[Post] 포스트 상세 페이지 로딩시 기본 프로필 수정

### DIFF
--- a/lib/views/my_page/widgets/my_profile_screen.dart
+++ b/lib/views/my_page/widgets/my_profile_screen.dart
@@ -8,7 +8,8 @@ class MyProfileScreen extends ConsumerStatefulWidget {
   const MyProfileScreen({super.key});
 
   @override
-  ConsumerState<MyProfileScreen> createState() => _MyProfileScreenState();
+  ConsumerState<MyProfileScreen> createState() =>
+      _MyProfileScreenState();
 }
 
 class _MyProfileScreenState extends ConsumerState<MyProfileScreen> {
@@ -16,7 +17,9 @@ class _MyProfileScreenState extends ConsumerState<MyProfileScreen> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      await ref.read(profileViewModelProvider.notifier).fetchUserProfile();
+      await ref
+          .read(profileViewModelProvider.notifier)
+          .fetchUserProfile();
     });
   }
 
@@ -34,7 +37,7 @@ class _MyProfileScreenState extends ConsumerState<MyProfileScreen> {
                 profileState.profileImageUrl != null
                     ? NetworkImage(profileState.profileImageUrl!)
                     : null, // TODO: 프로필이미지 없는 경우
-            backgroundColor: AppColors.primary[100],
+            backgroundColor: AppColors.grey[100],
           ),
           const SizedBox(height: 15),
           Text(
@@ -52,7 +55,9 @@ class _MyProfileScreenState extends ConsumerState<MyProfileScreen> {
             onTap: () async {
               final result = await Navigator.push(
                 context,
-                MaterialPageRoute(builder: (context) => EditProfilePage()),
+                MaterialPageRoute(
+                  builder: (context) => EditProfilePage(),
+                ),
               );
               if (result == true) {
                 await ref

--- a/lib/views/post/widgets/detail/post_detail_header.dart
+++ b/lib/views/post/widgets/detail/post_detail_header.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:travel_muse_app/constants/app_colors.dart';
 
 class PostDetailHeader extends StatelessWidget {
   const PostDetailHeader({
@@ -15,20 +16,19 @@ class PostDetailHeader extends StatelessWidget {
       children: [
         CircleAvatar(
           radius: 24,
-          backgroundColor: const Color(0xFFCED2D4),
+          backgroundColor: AppColors.grey[100],
           backgroundImage:
               (profileUrl?.isNotEmpty ?? false)
                   ? NetworkImage(profileUrl!)
-                  : null,
-          child:
-              (profileUrl?.isEmpty ?? true)
-                  ? const Text('프로필', style: TextStyle(fontSize: 12))
                   : null,
         ),
         const SizedBox(width: 12),
         Text(
           nickname ?? '닉네임',
-          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+          style: const TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w500,
+          ),
         ),
       ],
     );

--- a/lib/views/post/widgets/detail/post_detail_header.dart
+++ b/lib/views/post/widgets/detail/post_detail_header.dart
@@ -24,7 +24,7 @@ class PostDetailHeader extends StatelessWidget {
         ),
         const SizedBox(width: 12),
         Text(
-          nickname ?? '닉네임',
+          nickname ?? '',
           style: const TextStyle(
             fontSize: 16,
             fontWeight: FontWeight.w500,


### PR DESCRIPTION
### 🚀: 개요
- 포스트 상세 페이지 로딩시 기본 프로필 수정

### 🚀: 작업 내용
- 포스트 상세 페이지 로딩시 기본 이미지 회색 배경 설정, 텍스트 제거
- 포스트 상세 페이지 로딩시 기본 닉네임 빈 String으로 변경
- 마이페이지 내 프로필 이미지 기본 이미지 회색 배경 설정

### 📸: 실행 화면
<img src="https://github.com/user-attachments/assets/bfd52740-5c5e-4d06-b742-694e55c162d4" width="300" height="640"/>

### 🚀: 조정 파일
- lib/views/my_page/widgets/my_profile_screen.dart
- lib/views/post/widgets/detail/post_detail_header.dart

### 개발 결과
- 포스트 상세 페이지 로딩 시 기본 프로필 수정 완료
- 마이페이지 내 프로필 이미지 기본 이미지 로딩 시와 색상 통일 완료

### issue
Closes #282
