### PR TITLE
[Etc] 약관 표시 방식 변경

### DIFF
--- a/lib/constants/markdown_style_sheet.dart
+++ b/lib/constants/markdown_style_sheet.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:travel_muse_app/constants/app_colors.dart';
+
+MarkdownStyleSheet markdownStyle = MarkdownStyleSheet(
+  h1: TextStyle(
+    fontSize: 24,
+    height: 1.5,
+    fontWeight: FontWeight.bold,
+    color: AppColors.primary[500],
+  ),
+  h2: TextStyle(
+    fontSize: 20,
+    height: 1.5,
+    fontWeight: FontWeight.bold,
+  ),
+  p: TextStyle(fontSize: 16, height: 1.5, color: AppColors.grey[600]),
+  pPadding: EdgeInsets.only(bottom: 16),
+  strong: TextStyle(fontWeight: FontWeight.bold),
+  listBullet: TextStyle(fontSize: 16),
+  code: TextStyle(
+    fontFamily: 'Pretendard',
+    fontSize: 14,
+    backgroundColor: AppColors.grey[100],
+  ),
+  horizontalRuleDecoration: BoxDecoration(
+    border: Border(
+      top: BorderSide(color: AppColors.grey[300]!, width: 0.5),
+    ),
+  ),
+);

--- a/lib/constants/markdown_style_sheet.dart
+++ b/lib/constants/markdown_style_sheet.dart
@@ -7,10 +7,11 @@ MarkdownStyleSheet markdownStyle = MarkdownStyleSheet(
     fontSize: 24,
     height: 1.5,
     fontWeight: FontWeight.bold,
-    color: AppColors.primary[500],
+    color: AppColors.black,
   ),
   h2: TextStyle(
     fontSize: 20,
+    color: AppColors.grey[700],
     height: 1.5,
     fontWeight: FontWeight.bold,
   ),

--- a/lib/views/my_page/settings/service_term_page.dart
+++ b/lib/views/my_page/settings/service_term_page.dart
@@ -1,105 +1,99 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
-import 'package:travel_muse_app/views/user/onboarding/terms_web_view_page.dart';
+import 'package:travel_muse_app/providers/user/terms_view_model_provider.dart';
+import 'package:travel_muse_app/views/user/onboarding/terms_detail_page.dart';
 import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
-final List<Map<String, String>> termsData = [
-  {
-    'title': '서비스 이용약관',
-    'url': 'https://www.notion.so/21cc9d67bce980ab9579ebf380ad5d2c',
-  },
-  {
-    'title': '개인정보 처리방침',
-    'url': 'https://www.notion.so/21cc9d67bce980d58f34ec20ee46d139',
-  },
-  {
-    'title': '마케팅 수신 동의',
-    'url': 'https://www.notion.so/21cc9d67bce980ab9579ebf380ad5d2c?pvs=12',
-  },
-  {
-    'title': '커뮤니티 운영정책',
-    'url': 'https://www.notion.so/21cc9d67bce980b1a257c3a7dcf39cc2',
-  },
-  {
-    'title': '위치정보 이용동의',
-    'url': 'https://www.notion.so/21cc9d67bce9802e92f5fbaceffe6190',
-  },
-];
-
-class ServiceTermPage extends StatelessWidget {
+class ServiceTermPage extends ConsumerWidget {
   const ServiceTermPage({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final termsListAsync = ref.watch(termsViewModelProvider);
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('서비스 약관', style: TextStyle()),
-        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
+        leading:
+            Navigator.canPop(context)
+                ? const CustomBackButton()
+                : null,
       ),
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        child: ListView.builder(
-          itemCount: termsData.length,
-          itemBuilder: (context, index) {
-            final term = termsData[index];
-            return GestureDetector(
-              onTap:
-                  term['url'] != null && term['url']!.isNotEmpty
-                      ? () {
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder:
-                                (_) => TermsWebViewPage(
-                                  title: term['title']!,
-                                  url: term['url']!,
+      body: termsListAsync.when(
+        data:
+            (data) => Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: ListView.builder(
+                itemCount: data.length,
+                itemBuilder: (context, index) {
+                  final term = data[index];
+                  return GestureDetector(
+                    onTap:
+                        term.content.isNotEmpty
+                            ? () {
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder:
+                                      (_) =>
+                                          TermsDetailPage(term: term),
                                 ),
+                              );
+                            }
+                            : null,
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 16,
+                        vertical: 16,
+                      ),
+                      decoration: BoxDecoration(
+                        border: Border(
+                          bottom: BorderSide(
+                            width: 1,
+                            color: AppColors.grey[50]!,
                           ),
-                        );
-                      }
-                      : null,
-              child: Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 16,
-                  vertical: 16,
-                ),
-                decoration: BoxDecoration(
-                  border: Border(
-                    bottom: BorderSide(width: 1, color: AppColors.grey[50]!),
-                  ),
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    SizedBox(
-                      width: MediaQuery.of(context).size.width * 0.75,
-                      child: Text(
-                        term['title']!,
-                        overflow: TextOverflow.ellipsis,
-                        maxLines: 1,
-                        style: TextStyle(
-                          color: AppColors.black,
-                          fontSize: 16,
-                          fontFamily: 'Pretendard',
-                          fontWeight: FontWeight.w600,
-                          height: 1.50,
                         ),
                       ),
+                      child: Row(
+                        mainAxisAlignment:
+                            MainAxisAlignment.spaceBetween,
+                        children: [
+                          SizedBox(
+                            width:
+                                MediaQuery.of(context).size.width *
+                                0.75,
+                            child: Text(
+                              term.title,
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 1,
+                              style: TextStyle(
+                                color: AppColors.black,
+                                fontSize: 16,
+                                fontFamily: 'Pretendard',
+                                fontWeight: FontWeight.w600,
+                                height: 1.50,
+                              ),
+                            ),
+                          ),
+                          term.content.isNotEmpty
+                              ? Icon(
+                                Icons.arrow_forward_ios,
+                                size: 16,
+                                color: AppColors.grey[600],
+                              )
+                              : SizedBox.shrink(),
+                        ],
+                      ),
                     ),
-                    term['url'] != null && term['url']!.isNotEmpty
-                        ? Icon(
-                          Icons.arrow_forward_ios,
-                          size: 16,
-                          color: AppColors.grey[600],
-                        )
-                        : SizedBox.shrink(),
-                  ],
-                ),
+                  );
+                },
               ),
-            );
-          },
-        ),
+            ),
+        error:
+            (error, st) => Center(child: CircularProgressIndicator()),
+        loading: () => Center(child: CircularProgressIndicator()),
       ),
       bottomNavigationBar: const BottomBar(),
     );

--- a/lib/views/my_page/settings/setting_page.dart
+++ b/lib/views/my_page/settings/setting_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/views/my_page/settings/account_setting_page.dart';
-import 'package:travel_muse_app/views/my_page/settings/environment_setting_page.dart';
 import 'package:travel_muse_app/views/my_page/settings/notification_setting_page.dart';
 import 'package:travel_muse_app/views/my_page/settings/service_term_page.dart';
 import 'package:travel_muse_app/views/my_page/settings/support_page.dart';
@@ -43,7 +42,9 @@ class _SettingPageState extends State<SettingPage> {
   @override
   Widget build(BuildContext context) {
     if (_loading) {
-      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
     }
 
     final List<Map<String, dynamic>> settingsItems = [
@@ -52,14 +53,22 @@ class _SettingPageState extends State<SettingPage> {
       {'title': '서비스 약관', 'route': const ServiceTermPage()},
       {'title': '고객 지원', 'route': const SupportPage()},
       {'title': '버전 정보', 'route': const VersionPage()},
-      if (_isAdmin) {'title': '운영자 권한 설정', 'route': const AdminEntry()},
-      if (_isAdmin) {'title': '신고 컨텐츠 관리', 'route': const AdminReportEntry()},
+      if (_isAdmin)
+        {'title': '운영자 권한 설정', 'route': const AdminEntry()},
+      if (_isAdmin)
+        {'title': '신고 컨텐츠 관리', 'route': const AdminReportEntry()},
     ];
 
     return Scaffold(
       appBar: AppBar(
-        title: Text('설정', style: TextStyle(color: AppColors.grey[800])),
-        leading: Navigator.canPop(context) ? const CustomBackButton() : null,
+        title: Text(
+          '설정',
+          style: TextStyle(color: AppColors.grey[800]),
+        ),
+        leading:
+            Navigator.canPop(context)
+                ? const CustomBackButton()
+                : null,
       ),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 16),
@@ -82,7 +91,10 @@ class _SettingPageState extends State<SettingPage> {
                 ),
                 decoration: BoxDecoration(
                   border: Border(
-                    bottom: BorderSide(width: 1, color: AppColors.grey[50]!),
+                    bottom: BorderSide(
+                      width: 1,
+                      color: AppColors.grey[50]!,
+                    ),
                   ),
                 ),
                 child: Row(

--- a/lib/views/user/onboarding/terms_detail_bottom_sheet.dart
+++ b/lib/views/user/onboarding/terms_detail_bottom_sheet.dart
@@ -5,6 +5,7 @@ import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/constants/markdown_style_sheet.dart';
 import 'package:travel_muse_app/models/user/terms_model.dart';
+import 'package:travel_muse_app/providers/user/user_agreement_view_model_provider.dart';
 import 'package:travel_muse_app/views/user/onboarding/widgets/duplicate_button_themes.dart';
 
 class TermsDetailBottomSheet extends ConsumerWidget {
@@ -30,7 +31,7 @@ class TermsDetailBottomSheet extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            SizedBox(height: 24),
+            SizedBox(height: 28),
             Expanded(
               child: ListView(
                 children: [
@@ -44,9 +45,16 @@ class TermsDetailBottomSheet extends ConsumerWidget {
                 ],
               ),
             ),
+            SizedBox(height: 8),
             GestureDetector(
               onTap: () {
-                // 해당 약관 동의 처리
+                ref
+                    .read(userAgreementViewModelProvider.notifier)
+                    .toggleAgreedByTermId(
+                      termId: term.id,
+                      agreeOnly: true,
+                    );
+                Navigator.pop(context);
               },
               child: Container(
                 height: 56,

--- a/lib/views/user/onboarding/terms_detail_page.dart
+++ b/lib/views/user/onboarding/terms_detail_page.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:travel_muse_app/constants/markdown_style_sheet.dart';
+import 'package:travel_muse_app/models/user/terms_model.dart';
+import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
+
+class TermsDetailPage extends StatelessWidget {
+  const TermsDetailPage({super.key, required this.term});
+
+  final Terms term;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(term.title),
+        leading:
+            Navigator.canPop(context)
+                ? const CustomBackButton()
+                : null,
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: ListView(
+                children: [
+                  Markdown(
+                    data: term.content,
+                    shrinkWrap: true,
+                    physics: NeverScrollableScrollPhysics(),
+                    softLineBreak: true,
+                    styleSheet: markdownStyle,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          SizedBox(height: 40),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/user/onboarding/widgets/terms_detail_bottom_sheet.dart
+++ b/lib/views/user/onboarding/widgets/terms_detail_bottom_sheet.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:travel_muse_app/constants/app_colors.dart';
+import 'package:travel_muse_app/constants/app_text_styles.dart';
+import 'package:travel_muse_app/views/user/onboarding/widgets/duplicate_button_themes.dart';
+
+class TermsDetailBottomSheet extends ConsumerWidget {
+  const TermsDetailBottomSheet({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final screenHeight = MediaQuery.of(context).size.height;
+    return Container(
+      padding: EdgeInsets.symmetric(horizontal: 16),
+      width: double.infinity,
+      height: screenHeight * 0.75,
+      decoration: BoxDecoration(
+        color: AppColors.white,
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      child: SizedBox(
+        width: double.infinity,
+        height: double.maxFinite,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(height: 34),
+            Text(
+              'terms title',
+              style: TextStyle(
+                color: AppColors.black,
+                fontSize: 20,
+                fontFamily: 'Pretendard',
+                fontWeight: FontWeight.w700,
+                height: 1.50,
+              ),
+            ),
+            SizedBox(height: 16),
+            Expanded(
+              child: ListView(
+                children: [
+                  Text(
+                    'terms content',
+                    style: AppTextStyles.termsText,
+                  ),
+                ],
+              ),
+            ),
+            GestureDetector(
+              onTap: () {
+                // 해당 약관 동의 처리
+              },
+              child: Container(
+                height: 56,
+                width: double.infinity,
+                clipBehavior: Clip.antiAlias,
+                decoration: DuplicateButtonThemes.availableBoxStyle,
+                child: Center(
+                  child: Text(
+                    '동의하기',
+                    style: AppTextStyles.avaliableButtonText,
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(height: 34),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/user/onboarding/widgets/terms_detail_bottom_sheet.dart
+++ b/lib/views/user/onboarding/widgets/terms_detail_bottom_sheet.dart
@@ -1,15 +1,21 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/constants/app_text_styles.dart';
+import 'package:travel_muse_app/constants/markdown_style_sheet.dart';
+import 'package:travel_muse_app/models/user/terms_model.dart';
 import 'package:travel_muse_app/views/user/onboarding/widgets/duplicate_button_themes.dart';
 
 class TermsDetailBottomSheet extends ConsumerWidget {
-  const TermsDetailBottomSheet({super.key});
+  const TermsDetailBottomSheet({super.key, required this.term});
+
+  final Terms term;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final screenHeight = MediaQuery.of(context).size.height;
+
     return Container(
       padding: EdgeInsets.symmetric(horizontal: 16),
       width: double.infinity,
@@ -24,24 +30,16 @@ class TermsDetailBottomSheet extends ConsumerWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            SizedBox(height: 34),
-            Text(
-              'terms title',
-              style: TextStyle(
-                color: AppColors.black,
-                fontSize: 20,
-                fontFamily: 'Pretendard',
-                fontWeight: FontWeight.w700,
-                height: 1.50,
-              ),
-            ),
-            SizedBox(height: 16),
+            SizedBox(height: 24),
             Expanded(
               child: ListView(
                 children: [
-                  Text(
-                    'terms content',
-                    style: AppTextStyles.termsText,
+                  Markdown(
+                    data: term.content,
+                    shrinkWrap: true,
+                    physics: NeverScrollableScrollPhysics(),
+                    softLineBreak: true,
+                    styleSheet: markdownStyle,
                   ),
                 ],
               ),

--- a/lib/views/user/onboarding/widgets/terms_list.dart
+++ b/lib/views/user/onboarding/widgets/terms_list.dart
@@ -4,7 +4,6 @@ import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/models/user/terms_model.dart';
 import 'package:travel_muse_app/providers/user/terms_view_model_provider.dart';
-import 'package:travel_muse_app/views/user/onboarding/terms_web_view_page.dart';
 import 'package:travel_muse_app/views/user/onboarding/widgets/custom_check_toggle.dart';
 import 'package:travel_muse_app/views/user/onboarding/widgets/terms_detail_bottom_sheet.dart';
 
@@ -55,14 +54,14 @@ class TermsList extends ConsumerWidget {
     required BuildContext context,
     required Terms term,
   }) {
-    return term.url.isNotEmpty
+    return term.content.isNotEmpty
         ? GestureDetector(
           onTap: () {
             showModalBottomSheet(
               context: context,
               isScrollControlled: true,
               builder: (context) {
-                return const TermsDetailBottomSheet();
+                return TermsDetailBottomSheet(term: term);
               },
             );
           },

--- a/lib/views/user/onboarding/widgets/terms_list.dart
+++ b/lib/views/user/onboarding/widgets/terms_list.dart
@@ -6,6 +6,7 @@ import 'package:travel_muse_app/models/user/terms_model.dart';
 import 'package:travel_muse_app/providers/user/terms_view_model_provider.dart';
 import 'package:travel_muse_app/views/user/onboarding/terms_web_view_page.dart';
 import 'package:travel_muse_app/views/user/onboarding/widgets/custom_check_toggle.dart';
+import 'package:travel_muse_app/views/user/onboarding/widgets/terms_detail_bottom_sheet.dart';
 
 class TermsList extends ConsumerWidget {
   const TermsList({super.key});
@@ -25,7 +26,9 @@ class TermsList extends ConsumerWidget {
                     width: double.maxFinite,
                     child: Row(
                       children: [
-                        CustomCheckToggle(termId: termsList[index].id),
+                        CustomCheckToggle(
+                          termId: termsList[index].id,
+                        ),
                         SizedBox(width: 12),
                         Text(
                           '''${termsList[index].isRequired ? '(필수)' : '(선택)'} ${termsList[index].title}''',
@@ -39,7 +42,8 @@ class TermsList extends ConsumerWidget {
                       ],
                     ),
                   ),
-              separatorBuilder: (context, index) => SizedBox(height: 12),
+              separatorBuilder:
+                  (context, index) => SizedBox(height: 12),
             ),
         loading: () => CircularProgressIndicator(),
         error: (e, _) => Text('약관 불러오기 실패: $e'),
@@ -54,12 +58,12 @@ class TermsList extends ConsumerWidget {
     return term.url.isNotEmpty
         ? GestureDetector(
           onTap: () {
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder:
-                    (_) => TermsWebViewPage(title: term.title, url: term.url),
-              ),
+            showModalBottomSheet(
+              context: context,
+              isScrollControlled: true,
+              builder: (context) {
+                return const TermsDetailBottomSheet();
+              },
             );
           },
           child: Text(

--- a/lib/views/user/onboarding/widgets/terms_list.dart
+++ b/lib/views/user/onboarding/widgets/terms_list.dart
@@ -4,8 +4,8 @@ import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/constants/app_text_styles.dart';
 import 'package:travel_muse_app/models/user/terms_model.dart';
 import 'package:travel_muse_app/providers/user/terms_view_model_provider.dart';
+import 'package:travel_muse_app/views/user/onboarding/terms_detail_bottom_sheet.dart';
 import 'package:travel_muse_app/views/user/onboarding/widgets/custom_check_toggle.dart';
-import 'package:travel_muse_app/views/user/onboarding/widgets/terms_detail_bottom_sheet.dart';
 
 class TermsList extends ConsumerWidget {
   const TermsList({super.key});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -478,6 +478,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  flutter_markdown:
+    dependency: "direct main"
+    description:
+      name: flutter_markdown
+      sha256: "08fb8315236099ff8e90cb87bb2b935e0a724a3af1623000a9cec930468e0f27"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.7+1"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -832,6 +840,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  markdown:
+    dependency: transitive
+    description:
+      name: markdown
+      sha256: "935e23e1ff3bc02d390bad4d4be001208ee92cc217cb5b5a6c19bc14aaa318c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.3.0"
   matcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ dependencies:
   cloud_functions: ^5.5.2
   collection: ^1.19.1
   quiver: ^3.2.2
+  flutter_markdown: ^0.7.7+1
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### 🚀: 개요
- 약관 표시 방식 변경

### 🚀: 작업 내용
- 약관 동의 시 표시 방식 변경(바텀시트)
- 설정 페이지/서비스 약관 페이지 각 약관 표시 방식 변경(페이지)

### 📸: 실행 화면
<img src="https://github.com/user-attachments/assets/546967f8-452f-46a2-9830-d556d86410de" width="300" height="640"/>
<img src="https://github.com/user-attachments/assets/685e193e-b78f-4907-91db-e917d7d970e3" width="300" height="640"/>

### 🚀: 조정 파일
- lib/constants/markdown_style_sheet.dart
- lib/views/my_page/settings/service_term_page.dart
- lib/views/user/onboarding/terms_detail_bottom_sheet.dart
- lib/views/user/onboarding/terms_detail_page.dart
- lib/views/user/onboarding/widgets/terms_list.dart

### 개발 결과
- 약관 표시 방식 웹뷰에서 String 마크다운 표시로 변경

### issue
Closes #298
