### PR TITLE
[Plan] 일정 전체 드래그앤 드랍 기능 구현

### DIFF
--- a/assets/icons/plus-circle.svg
+++ b/assets/icons/plus-circle.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" fill="#4991FE" stroke="#4991FE" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 8V16" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M8 12H16" stroke="white" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/icons/x-circle.svg
+++ b/assets/icons/x-circle.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" stroke="#646E72" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 9L9 15" stroke="#646E72" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 9L15 15" stroke="#646E72" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/lib/views/plan/plan/schedule/schedule_page.dart
+++ b/lib/views/plan/plan/schedule/schedule_page.dart
@@ -30,6 +30,7 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
   bool _isEditing = false;
   Map<int, List<Map<String, String>>> daySchedules = {};
   Plans? selectedPlan;
+  final Map<int, bool> _expandedMap = {};
 
   @override
   void initState() {
@@ -53,12 +54,20 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
   }
 
   // 일정 편집 관련
-  void _onReorder(int dayIndex, int oldIndex, int newIndex) {
+  void _onReorder(int fromDay, int fromIndex, int toDay, int toIndex) {
     setState(() {
-      if (newIndex > oldIndex) newIndex -= 1;
-      final moved = daySchedules[dayIndex]!.removeAt(oldIndex);
-      daySchedules[dayIndex]!.insert(newIndex, moved);
+      final moved = daySchedules[fromDay]!.removeAt(fromIndex);
+      daySchedules.putIfAbsent(toDay, () => []);
+
+      final list = daySchedules[toDay]!;
+
+      final safeIndex = toIndex.clamp(0, list.length);
+      list.insert(safeIndex, moved);
     });
+
+    ref
+        .read(scheduleViewModelProvider.notifier)
+        .saveDaySchedules(planId: widget.planId, daySchedules: daySchedules);
   }
 
   Future<void> _addPlace(int dayIndex) async {
@@ -103,6 +112,17 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
     }
   }
 
+  void _insertPlace(int dayIndex, Map<String, String> place) {
+    setState(() {
+      daySchedules.putIfAbsent(dayIndex, () => []);
+      daySchedules[dayIndex]!.insert(0, place);
+    });
+
+    ref
+        .read(scheduleViewModelProvider.notifier)
+        .saveDaySchedules(planId: widget.planId, daySchedules: daySchedules);
+  }
+
   @override
   Widget build(BuildContext context) {
     final planState = ref.watch(scheduleViewModelProvider);
@@ -131,26 +151,37 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
                   return DayScheduleList(
                     selectedPlan: selectedPlan!,
                     daySchedules: daySchedules,
-
+                    expandedMap: _expandedMap,
+                    onToggleExpanded: (dayIndex) {
+                      setState(() {
+                        _expandedMap[dayIndex] =
+                            !(_expandedMap[dayIndex] ?? true);
+                      });
+                    },
                     isEditing: _isEditing,
                     onReorder: _onReorder,
                     onAddPlace: _addPlace,
                     onRemovePlace: _removePlace,
+                    onInsertPlace: _insertPlace,
                     onPlaceTap: (place) {
                       final converted = HomePlace(
                         id: place['id'] ?? '',
                         title: place['title'] ?? '',
-                        subtitle: place['subtitle'] ?? '', 
+                        subtitle: place['subtitle'] ?? '',
                         address: place['address'] ?? '',
-                        thumbnail: place['image']?? '', 
+                        thumbnail: place['image'] ?? '',
                         latLng: LatLng(
                           double.tryParse(place['lat'] ?? '') ?? 0.0,
                           double.tryParse(place['lng'] ?? '') ?? 0.0,
                         ),
-                        category: place['category'] ?? '', 
+                        category: place['category'] ?? '',
                       );
 
-                      PlaceDetailBottomSheet.show(context, converted, showSelectButton: false,);
+                      PlaceDetailBottomSheet.show(
+                        context,
+                        converted,
+                        showSelectButton: false,
+                      );
                     },
                   );
                 },

--- a/lib/views/plan/plan/schedule/widgets/day_schedule_list.dart
+++ b/lib/views/plan/plan/schedule/widgets/day_schedule_list.dart
@@ -1,6 +1,11 @@
+import 'package:drag_and_drop_lists/drag_and_drop_lists.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/svg.dart';
+import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/models/plan/plans.dart';
 import 'package:travel_muse_app/views/plan/plan/schedule/widgets/day_schedule_section.dart';
+import 'package:travel_muse_app/views/plan/plan/schedule/widgets/dotted_line_vertical.dart';
+import 'package:travel_muse_app/views/plan/plan/schedule/widgets/schedule_place_card.dart';
 
 class DayScheduleList extends StatelessWidget {
   const DayScheduleList({
@@ -8,18 +13,25 @@ class DayScheduleList extends StatelessWidget {
     required this.selectedPlan,
     required this.daySchedules,
     required this.isEditing,
+    required this.expandedMap,
+    required this.onToggleExpanded,
     required this.onReorder,
     required this.onAddPlace,
     required this.onRemovePlace,
+    required this.onInsertPlace,
     this.onPlaceTap,
   });
 
   final Plans selectedPlan;
   final Map<int, List<Map<String, String>>> daySchedules;
   final bool isEditing;
-  final void Function(int dayIndex, int oldIndex, int newIndex) onReorder;
+  final Map<int, bool> expandedMap;
+  final void Function(int dayIndex) onToggleExpanded;
+  final void Function(int fromDay, int fromIndex, int toDay, int toIndex)
+  onReorder;
   final Future<void> Function(int dayIndex) onAddPlace;
   final void Function(int dayIndex, int placeIndex) onRemovePlace;
+  final void Function(int dayIndex, Map<String, String> place) onInsertPlace;
   final void Function(Map<String, String> place)? onPlaceTap;
 
   String _getWeekday(int weekday) {
@@ -32,29 +44,166 @@ class DayScheduleList extends StatelessWidget {
     final dayCount =
         selectedPlan.endDate.difference(selectedPlan.startDate).inDays + 1;
 
-    return ListView.separated(
-      itemCount: dayCount,
-      separatorBuilder: (_, __) => const SizedBox(height: 4),
-      itemBuilder: (context, dayIndex) {
-        final currentDate =
-            selectedPlan.startDate.add(Duration(days: dayIndex));
-        final dayLabel =
-            '${currentDate.month}.${currentDate.day} (${_getWeekday(currentDate.weekday)})';
+    final lists = List.generate(dayCount, (dayIndex) {
+      final currentDate = selectedPlan.startDate.add(Duration(days: dayIndex));
+      final dayLabel =
+          '${currentDate.month}.${currentDate.day} (${_getWeekday(currentDate.weekday)})';
+      final isExpanded = expandedMap[dayIndex] ?? true;
 
-        daySchedules.putIfAbsent(dayIndex, () => []);
+      if (!isExpanded) {
+        return DragAndDropList(
+          header: DayScheduleSection(
+            dayIndex: dayIndex,
+            dayLabel: dayLabel,
+            isExpanded: isExpanded,
+            onToggle: () => onToggleExpanded(dayIndex),
+          ),
+          children: const [],
+          contentsWhenEmpty: const SizedBox.shrink(), 
+        );
+      }
 
-        return DayScheduleSection(
-          key: ValueKey('day-$dayIndex'),
+      daySchedules.putIfAbsent(dayIndex, () => []);
+      final scheduleCards = <DragAndDropItem>[];
+
+      if (isExpanded) {
+        if (daySchedules[dayIndex]!.isEmpty) {
+          scheduleCards.add(
+            DragAndDropItem(
+              canDrag: false,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                child: Row(
+                  children: [
+                    const SizedBox(width: 24),
+                    const DottedLineVertical(height: 116),
+                    Spacer(),
+                    Text(
+                      '아직 추가된 일정이 없어요',
+                      style: TextStyle(
+                        color: AppColors.grey[400],
+                        fontSize: 14,
+                        fontFamily: 'Pretendard',
+                      ),
+                    ),
+                    Spacer(),
+                  ],
+                ),
+              ),
+            ),
+          );
+        } else {
+          scheduleCards.addAll(
+            daySchedules[dayIndex]!.asMap().entries.map((entry) {
+              final placeIndex = entry.key;
+              final place = entry.value;
+
+              return DragAndDropItem(
+                child: IntrinsicHeight(
+                  child: Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const SizedBox(width: 24),
+                      const DottedLineVertical(height: 116),
+                      const SizedBox(width: 23),
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.only(bottom: 1),
+                          child: GestureDetector(
+                            onTap:
+                                isEditing
+                                    ? null
+                                    : () => onPlaceTap?.call(place),
+                            child: Row(
+                              children: [
+                                Expanded(
+                                  child: SchedulePlaceCard(
+                                    index: placeIndex + 1,
+                                    place: place,
+                                    showHandle: isEditing,
+                                  ),
+                                ),
+                                if (isEditing)
+                                  IconButton(
+                                    icon: SvgPicture.asset(
+                                      'assets/icons/x-circle.svg',
+                                      width: 24,
+                                      height: 24,
+                                    ),
+                                    onPressed:
+                                        () =>
+                                            onRemovePlace(dayIndex, placeIndex),
+                                  ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 20),
+                    ],
+                  ),
+                ),
+              );
+            }),
+          );
+        }
+
+        // 일정 추가 버튼
+        scheduleCards.add(
+          DragAndDropItem(
+            canDrag: false,
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 16),
+              child: IntrinsicHeight(
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const SizedBox(width: 47),
+                    Expanded(
+                      child: Center(
+                        child: IconButton(
+                          icon: SvgPicture.asset(
+                            'assets/icons/plus-circle.svg',
+                            width: 24,
+                            height: 24,
+                          ),
+                          onPressed: () => onAddPlace(dayIndex),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+
+      return DragAndDropList(
+        header: DayScheduleSection(
           dayIndex: dayIndex,
           dayLabel: dayLabel,
-          schedules: daySchedules[dayIndex]!,
-          isEditing: isEditing,
-          onReorder: onReorder,
-          onAddPlace: onAddPlace,
-          onRemovePlace: onRemovePlace,
-          onPlaceTap: onPlaceTap,
-        );
+          isExpanded: isExpanded,
+          onToggle: () => onToggleExpanded(dayIndex),
+        ),
+        children: isExpanded ? scheduleCards : [],
+        contentsWhenEmpty: isExpanded ? null : const SizedBox.shrink(),
+      );
+    });
+
+    return DragAndDropLists(
+      children: lists,
+      onItemReorder: (oldItemIndex, oldListIndex, newItemIndex, newListIndex) {
+        if (isEditing) {
+          onReorder(oldListIndex, oldItemIndex, newListIndex, newItemIndex);
+        }
       },
+      onListReorder: (_, __) {},
+      listPadding: const EdgeInsets.only(bottom: 16),
+      itemDragHandle: null,
+      listDragHandle: null,
+      listGhost: const SizedBox.shrink(),
     );
   }
 }

--- a/lib/views/plan/plan/schedule/widgets/day_schedule_section.dart
+++ b/lib/views/plan/plan/schedule/widgets/day_schedule_section.dart
@@ -1,124 +1,51 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_svg/flutter_svg.dart';
-import 'package:travel_muse_app/constants/app_colors.dart';
 import 'package:travel_muse_app/views/plan/plan/schedule/widgets/bullet.dart';
-import 'package:travel_muse_app/views/plan/plan/schedule/widgets/dotted_line_vertical.dart';
-import 'package:travel_muse_app/views/plan/plan/schedule/widgets/schedule_place_card.dart';
 
-const double _cardHeight = 100;
-
-class DayScheduleSection extends StatefulWidget {
+class DayScheduleSection extends StatelessWidget {
   const DayScheduleSection({
     super.key,
     required this.dayIndex,
     required this.dayLabel,
-    required this.schedules,
-    required this.isEditing,
-    required this.onReorder,
-    required this.onAddPlace,
-    required this.onRemovePlace,
-    this.onPlaceTap,
+    required this.isExpanded,
+    required this.onToggle,
   });
 
   final int dayIndex;
   final String dayLabel;
-  final List<Map<String, String>> schedules;
-  final bool isEditing;
-  final void Function(int dayIndex, int oldIndex, int newIndex) onReorder;
-  final void Function(int dayIndex) onAddPlace;
-  final void Function(int dayIndex, int placeIndex) onRemovePlace;
-  final void Function(Map<String, String> place)? onPlaceTap;
-
-  @override
-  State<DayScheduleSection> createState() => _DayScheduleSectionState();
-}
-
-class _DayScheduleSectionState extends State<DayScheduleSection>
-    with SingleTickerProviderStateMixin {
-  bool _expanded = true;
-  late final AnimationController _ctrl = AnimationController(
-    vsync: this,
-    duration: const Duration(milliseconds: 250),
-  );
-  late final Animation<double> _factor = CurvedAnimation(
-    parent: _ctrl,
-    curve: Curves.easeInOut,
-  );
-
-  @override
-  void initState() {
-    super.initState();
-    _ctrl.value = 1; // 처음엔 펼친 상태
-  }
-
-  void _toggle() {
-    setState(() => _expanded = !_expanded);
-    _expanded ? _ctrl.forward() : _ctrl.reverse();
-  }
+  final bool isExpanded;
+  final VoidCallback onToggle;
 
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      padding: const EdgeInsets.only(left: 13, top: 12, bottom: 4, right: 16),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // 타임라인 열
           Column(
-            mainAxisSize: MainAxisSize.min,
             children: [
               const Bullet(),
-              SizedBox(
-                height: _expanded ? _contentHeight : 0,
-                child: DottedLineVertical(
-                  height: _expanded ? _contentHeight : 0,
-                ),
-              ),
             ],
           ),
           const SizedBox(width: 12),
-
-          // 콘텐츠 열
           Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
+            child: Row(
               children: [
-                InkWell(
-                  onTap: _toggle,
-                  borderRadius: BorderRadius.circular(4),
-                  child: Row(
-                    children: [
-                      Text(
-                        'Day ${widget.dayIndex + 1}  ${widget.dayLabel}',
-                        style: const TextStyle(
-                          fontSize: 16,
-                          fontWeight: FontWeight.w600,
-                          fontFamily: 'Pretendard',
-                        ),
-                      ),
-                      const Spacer(),
-                      SvgPicture.asset(
-                        _expanded
-                            ? 'assets/icons/chevron-up.svg'
-                            : 'assets/icons/chevron-down.svg',
-                      ),
-                    ],
+                Text(
+                  'Day ${dayIndex + 1}  $dayLabel',
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    fontFamily: 'Pretendard',
                   ),
                 ),
-                const SizedBox(height: 16),
-
-                SizeTransition(
-                  sizeFactor: _factor,
-                  axisAlignment: -1,
-                  child: Column(
-                    children: [
-                      _buildCardList(),
-                      const SizedBox(height: 16),
-                      widget.schedules.isEmpty
-                          ? _buildEmptyView()
-                          : Center(child: _addBtn()),
-                      const SizedBox(height: 24),
-                    ],
+                const Spacer(),
+                GestureDetector(
+                  onTap: onToggle,
+                  child: Icon(
+                    isExpanded ? Icons.expand_less : Icons.expand_more,
+                    size: 24,
+                    color: Colors.grey[600],
                   ),
                 ),
               ],
@@ -127,95 +54,5 @@ class _DayScheduleSectionState extends State<DayScheduleSection>
         ],
       ),
     );
-  }
-
-  Widget _buildCardList() => ReorderableListView.builder(
-        shrinkWrap: true,
-        physics: const NeverScrollableScrollPhysics(),
-        itemCount: widget.schedules.length,
-        onReorder: widget.isEditing
-            ? (o, n) => widget.onReorder(widget.dayIndex, o, n)
-            : (_, __) {},
-        buildDefaultDragHandles: false,
-        itemBuilder: (context, i) {
-          final place = widget.schedules[i];
-          return Container(
-            key: ValueKey('${widget.dayIndex}-$i'),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.center,
-              children: [
-                // ✨ 클릭 가능하게 GestureDetector로 감싸기
-                Expanded(
-                  child: GestureDetector(
-                    onTap: widget.isEditing
-                        ? null
-                        : () => widget.onPlaceTap?.call(place),
-                    child: ReorderableDragStartListener(
-                      index: i,
-                      enabled: widget.isEditing,
-                      child: SchedulePlaceCard(
-                        index: i + 1,
-                        place: place,
-                        showHandle: widget.isEditing,
-                      ),
-                    ),
-                  ),
-                ),
-                if (widget.isEditing)
-                  Padding(
-                    padding: const EdgeInsets.only(left: 8),
-                    child: OutlinedButton(
-                      style: OutlinedButton.styleFrom(
-                        shape: const CircleBorder(),
-                        side: BorderSide(color: AppColors.grey[500]!),
-                        padding: EdgeInsets.zero,
-                        minimumSize: const Size(22, 22),
-                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                      ),
-                      onPressed: () =>
-                          widget.onRemovePlace(widget.dayIndex, i),
-                      child: Icon(
-                        Icons.close,
-                        size: 14,
-                        color: AppColors.grey[500],
-                      ),
-                    ),
-                  ),
-              ],
-            ),
-          );
-        },
-      );
-
-  Widget _buildEmptyView() => Center(
-        child: Column(
-          children: [
-            const SizedBox(height: 16),
-            Text(
-              '아직 추가된 일정이 없어요',
-              style: TextStyle(
-                fontSize: 14,
-                color: AppColors.grey[400],
-                fontFamily: 'Pretendard',
-              ),
-            ),
-            const SizedBox(height: 16),
-            _addBtn(),
-            const SizedBox(height: 24),
-          ],
-        ),
-      );
-
-  Widget _addBtn() => IconButton(
-        splashRadius: 22,
-        iconSize: 26,
-        color: AppColors.cpBlue,
-        onPressed: () => widget.onAddPlace(widget.dayIndex),
-        icon: const Icon(Icons.add_circle_rounded),
-      );
-
-  double get _contentHeight {
-    if (widget.schedules.isEmpty) return 110;
-    return widget.schedules.length * (_cardHeight + 8);
   }
 }

--- a/lib/views/plan/plan/schedule/widgets/schedule_place_card.dart
+++ b/lib/views/plan/plan/schedule/widgets/schedule_place_card.dart
@@ -1,3 +1,4 @@
+import 'package:drag_and_drop_lists/drag_and_drop_lists.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
@@ -18,7 +19,6 @@ class SchedulePlaceCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    // 편집 모드일 때만 카드 높이/패딩 축소
     final double cardMinH = showHandle ? 80 : 100;
     final double vPadding = showHandle ? 8 : 16;
 
@@ -53,7 +53,7 @@ class SchedulePlaceCard extends StatelessWidget {
             borderRadius: BorderRadius.circular(8.5),
             boxShadow: [
               BoxShadow(
-                color: Color.fromRGBO(0, 0, 0, 0.05),
+                color: const Color.fromRGBO(0, 0, 0, 0.05),
                 blurRadius: 4,
                 offset: const Offset(0, 2),
               ),
@@ -63,7 +63,7 @@ class SchedulePlaceCard extends StatelessWidget {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              //썸네일
+              // 썸네일
               ClipRRect(
                 borderRadius: BorderRadius.circular(10),
                 child: Image.network(
@@ -74,6 +74,8 @@ class SchedulePlaceCard extends StatelessWidget {
                 ),
               ),
               const SizedBox(width: 12),
+
+              // 텍스트 정보
               ConstrainedBox(
                 constraints: const BoxConstraints(maxWidth: 125),
                 child: Column(
@@ -120,15 +122,18 @@ class SchedulePlaceCard extends StatelessWidget {
                   ],
                 ),
               ),
+
               const Spacer(),
-              // 드래그 핸들
+
               if (showHandle)
-                Padding(
-                  padding: const EdgeInsets.only(right: 8),
-                  child: SvgPicture.asset(
-                    'assets/icons/menu.svg',
-                    width: 24,
-                    height: 24,
+                DragHandle(
+                  child: Padding(
+                    padding: const EdgeInsets.only(left: 8),
+                    child: SvgPicture.asset(
+                      'assets/icons/menu.svg',
+                      width: 24,
+                      height: 24,
+                    ),
                   ),
                 ),
             ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
   collection: ^1.19.1
   quiver: ^3.2.2
   flutter_markdown: ^0.7.7+1
+  drag_and_drop_lists: ^0.4.2
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Fixes #302

### 🚀: 개요
- 일정 전체 드래그앤 드랍 기능 구현

### 🚀: 작업 내용
-일정 전체 드래그앤 드랍 기능 구현
- drag_and_drop_lists 라이브러리 사용

### 🚀: 조정 파일
- day_schedule_list
- day_schedule_section
- schedule_place_card
- schedule_page
- pubspec.yaml
- plus-circle 추가
- x-circle 추가

### 개발 결과
-일정 전체 드래그앤 드랍으로 수정 가능

### issue
Closes #302 
