### PR TITLE
[Plan] 검색페이지, 홈화면 카테고리 추가

### DIFF
--- a/lib/models/home/home_place.dart
+++ b/lib/models/home/home_place.dart
@@ -14,6 +14,7 @@ class HomePlace {
     this.placeUrl,
     this.isFavorite = false,
     this.distance,
+    this.categoryCode
   });
 
   final String id;
@@ -27,6 +28,7 @@ class HomePlace {
   final String? placeUrl;
   final bool isFavorite;
   final int? distance;
+  final String? categoryCode; 
 
   factory HomePlace.fromPlace(Place p, {String thumb = '', int? distance}) {
     return HomePlace(
@@ -40,6 +42,7 @@ class HomePlace {
       phone: p.phone,
       placeUrl: p.placeUrl,
       distance: distance,
+      categoryCode: p.categoryCode,
     );
   }
 
@@ -59,6 +62,7 @@ class HomePlace {
       placeUrl: map['placeUrl'],
       isFavorite: map['isFavorite'] ?? false,
       distance: map['distance'],
+      categoryCode: map['categoryCode'],
     );
   }
 
@@ -76,6 +80,7 @@ class HomePlace {
       'placeUrl': placeUrl,
       'isFavorite': isFavorite,
       'distance': distance,
+      'categoryCode': categoryCode,
     };
   }
 }
@@ -92,5 +97,6 @@ extension PlaceMapping on Place {
     phone: phone,
     placeUrl: placeUrl,
     distance: distance,
+    categoryCode: categoryCode,
   );
 }

--- a/lib/models/home/home_state.dart
+++ b/lib/models/home/home_state.dart
@@ -2,23 +2,27 @@ import 'package:travel_muse_app/models/home/home_place.dart';
 
 class HomeState {
   const HomeState({
+    this.originalSpots = const <HomePlace>[],
     this.spots = const <HomePlace>[],
     this.foods = const <HomePlace>[],
     this.spotPage = 1,
     this.foodPage = 1,
   });
 
+  final List<HomePlace> originalSpots;
   final List<HomePlace> spots;
   final List<HomePlace> foods;
   final int spotPage;
   final int foodPage;
 
   HomeState copyWith({
+    List<HomePlace>? originalSpots,
     List<HomePlace>? spots,
     List<HomePlace>? foods,
     int? spotPage,
     int? foodPage,
   }) => HomeState(
+    originalSpots: originalSpots ?? this.originalSpots,
     spots: spots ?? this.spots,
     foods: foods ?? this.foods,
     spotPage: spotPage ?? this.spotPage,

--- a/lib/models/plan/place.dart
+++ b/lib/models/plan/place.dart
@@ -9,7 +9,8 @@ class Place {
     required this.longitude,
     required this.category,
     required this.phone,
-    required this.placeUrl
+    required this.placeUrl,
+    this.categoryCode
   });
 
   final String id;
@@ -21,7 +22,8 @@ class Place {
   final double longitude;
   final String category;
   final String? phone;        
-  final String? placeUrl;    
+  final String? placeUrl;  
+  final String? categoryCode;  
 
   factory Place.fromKakaoJson(Map<String, dynamic> json) {
     final address = json['address_name'] ?? '';
@@ -37,7 +39,8 @@ class Place {
       longitude: double.tryParse(json['x'] ?? '0') ?? 0,
       category: json['category_name'] ?? '',
       phone: json['phone'] ?? '',
-      placeUrl: json['placeUrl'] ?? ''
+      placeUrl: json['placeUrl'] ?? '',
+      categoryCode: json['category_group_code'],
     );
   }
 }

--- a/lib/providers/plan/schedule/selected_category_provider.dart
+++ b/lib/providers/plan/schedule/selected_category_provider.dart
@@ -1,0 +1,3 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final selectedCategoryProvider = StateProvider<String>((ref) => '전체');

--- a/lib/services/plan/nearby_place_service.dart
+++ b/lib/services/plan/nearby_place_service.dart
@@ -58,4 +58,19 @@ class NearbyPlaceService {
     page: page,
     size: size,
   );
+  //카테고리 코드 기반 검색
+  Future<List<Place>> fetchSpotsByCategory({
+    required LatLng loc,
+    required String categoryCode,
+    int radius = 10000,
+    int page = 1,
+    int size = 15,
+  }) => base.searchByCategory(
+    categoryCode: categoryCode,
+    lat: loc.latitude,
+    lng: loc.longitude,
+    radius: radius,
+    page: page,
+    size: size,
+  );
 }

--- a/lib/services/plan/nearby_place_service.dart
+++ b/lib/services/plan/nearby_place_service.dart
@@ -2,29 +2,11 @@ import 'package:google_maps_flutter/google_maps_flutter.dart';
 import 'package:travel_muse_app/models/plan/place.dart';
 import 'package:travel_muse_app/services/plan/place_search_service.dart';
 
-///  - 명소(AT4) · 맛집(FD6) 등 카테고리 전용 호출
 ///  - 키워드 + 위치 검색
 class NearbyPlaceService {
   NearbyPlaceService(this.base);
 
   final PlaceSearchService base;
-
-  //명소(관광)
-  /// 내 위치 [loc] 기준 관광명소(카테고리 AT4)를 거리순으로 가져옵니다.
-  /// [radius] : 검색 반경(m) – 10000m(10km) 기본
-  Future<List<Place>> fetchSpots({
-    required LatLng loc,
-    int radius = 10000,
-    int page = 1,
-    int size = 15,
-  }) => base.searchByCategory(
-    categoryCode: 'AT4',
-    lat: loc.latitude,
-    lng: loc.longitude,
-    radius: radius,
-    page: page,
-    size: size,
-  );
 
   //맛집(음식점)
   /// 내 위치 [loc] 기준 맛집(카테고리 FD6)를 거리순으로 가져옵니다.

--- a/lib/viewmodels/home/home_view_model.dart
+++ b/lib/viewmodels/home/home_view_model.dart
@@ -21,15 +21,15 @@ class HomeViewModel extends StateNotifier<AsyncValue<HomeState>> {
 
   //초기 로드
   Future<void> _init() async {
-  try {
-    // 위치 권한 GPS 오류가 나면 catch 블록에서 폴백 좌표 사용
-    final loc = await _ref.read(locationProvider.future);
-    await load(loc);
-  } catch (_) {
-    // 권한 OFF 실패 시 기본 좌표로 추천 불러오기
-    await load(kFallbackLatLng);
+    try {
+      // 위치 권한 GPS 오류가 나면 catch 블록에서 폴백 좌표 사용
+      final loc = await _ref.read(locationProvider.future);
+      await load(loc);
+    } catch (_) {
+      // 권한 OFF 실패 시 기본 좌표로 추천 불러오기
+      await load(kFallbackLatLng);
+    }
   }
-}
 
   //썸네일 병렬 로드 + 매핑
   Future<List<HomePlace>> _mapWithThumbs(List<Place> raw) async {
@@ -47,61 +47,34 @@ class HomeViewModel extends StateNotifier<AsyncValue<HomeState>> {
   }
 
   //첫 페이지 로드
-  Future<void> load(LatLng loc) async {
+  Future<void> load(LatLng loc, {String? categoryCode}) async {
     state = const AsyncLoading();
 
     state = await AsyncValue.guard(() async {
-      final rawSpots = await _svc.fetchSpots(loc: loc, page: 1);
+      final rawSpots = await _svc.fetchSpotsByCategory(
+        loc: loc,
+        categoryCode: categoryCode ?? 'AT4',
+        page: 1,
+      );
       final rawFoods = await _svc.fetchFoods(loc: loc, page: 1);
 
       final spots = await _mapWithThumbs(rawSpots);
       final foods = await _mapWithThumbs(rawFoods);
 
-      return HomeState(spots: spots, foods: foods);
+      return HomeState(
+        originalSpots: spots, // AT4 원본 저장
+        spots: spots,
+        foods: foods,
+      );
     });
   }
 
   List<HomePlace> getFilteredSpots(List<HomePlace> spots, String? selectedTag) {
-    const tagCategoryMap = {
-      '#전체': [
-        '자연',
-        '산책',
-        '강',
-        '호수',
-        '공원',
-        '숲',
-        '휴양',
-        '계곡',
-        '풍경',
-        '정원',
-        '드라이브',
-        '힐링',
-        '산',
-        '둘레길',
-        '도보여행',
-        '전망대',
-        '산책로',
-        '야경',
-        '피톤치드',
-        '문화',
-        '유적',
-        '사적',
-        '역사',
-        '고궁',
-        '성',
-        '탑',
-        '박물관',
-        '기념관',
-        '전통',
-        '사찰',
-        '고건축',
-        '유교',
-        '불교',
-        '서원',
-        '문화재',
-        '유물',
-        '전시관',
-      ],
+    if (selectedTag == null || selectedTag == '#전체') return spots;
+
+    const categoryCodeMap = {'#카페': 'CE7', '#가볼만한 곳': 'CT1'};
+
+    const tagKeywordMap = {
       '#힐링': [
         '자연',
         '산책',
@@ -206,14 +179,45 @@ class HomeViewModel extends StateNotifier<AsyncValue<HomeState>> {
         '아쿠아리움',
         '키즈카페',
         '실내놀이터',
+        '놀이터',
+        '놀이',
+        '가족',
+        '테마',
       ],
     };
+    if (categoryCodeMap.containsKey(selectedTag)) {
+      final code = categoryCodeMap[selectedTag];
+      return spots.where((p) => p.categoryCode?.toUpperCase() == code).toList();
+    }
 
-    if (selectedTag == null) return spots;
-
-    final keywords = tagCategoryMap[selectedTag] ?? [];
+    final keywords = tagKeywordMap[selectedTag] ?? [];
     return spots
-        .where((p) => keywords.any((kw) => p.category.contains(kw)))
+        .where((p) => keywords.any((k) => p.category.contains(k)))
         .toList();
+  }
+
+  Future<void> reloadWithTag(String selectedTag) async {
+    const categoryCodeMap = {'#자연': 'AT4', '#카페': 'CE7', '#가볼만한 곳': 'CT1'};
+
+    final code = categoryCodeMap[selectedTag];
+    final loc = await _ref.read(locationProvider.future);
+
+    if (code != null) {
+      final raw = await _svc.fetchSpotsByCategory(loc: loc, categoryCode: code);
+      final mapped = await _mapWithThumbs(raw);
+
+      final current = state.value;
+      if (current != null) {
+        state = AsyncValue.data(
+          current.copyWith(spots: mapped), 
+        );
+      }
+    } else {
+      // 코드 없을 땐 원래 AT4 원본에서 다시 보여줌
+      final current = state.value;
+      if (current != null) {
+        state = AsyncValue.data(current.copyWith(spots: current.originalSpots));
+      }
+    }
   }
 }

--- a/lib/viewmodels/plan/search_view_model.dart
+++ b/lib/viewmodels/plan/search_view_model.dart
@@ -32,16 +32,29 @@ class SearchViewModel extends StateNotifier<List<Map<String, String>>> {
     }
   }
 
-  ///추천 명소 맛집 로드 (지역 기반)
-  Future<void> loadRecommendedByRegion(String region) async {
+  ///추천 명소 로드 (지역 기반)
+  Future<void> loadRecommendedByRegion(
+    String region, [
+    String? categoryCode,
+  ]) async {
     final latLng = await _placeService.getLatLngFromRegion(region);
     if (latLng == null) return;
 
-    final spots = await _nearbyService.fetchSpots(loc: latLng);
-    final foods = await _nearbyService.fetchFoods(loc: latLng);
-    final combined = await _mapPlacesToViewData([...spots, ...foods]);
+    List<Place> places;
 
-    state = combined;
+    if (categoryCode == null) {
+      final spots = await _nearbyService.fetchSpots(loc: latLng);
+      final foods = await _nearbyService.fetchFoods(loc: latLng);
+      places = [...spots, ...foods];
+    } else {
+      places = await _nearbyService.fetchSpotsByCategory(
+        loc: latLng,
+        categoryCode: categoryCode,
+      );
+    }
+
+    final result = await _mapPlacesToViewData(places);
+    state = result;
   }
 
   ///지역 기반 또는 전국 검색 처리

--- a/lib/viewmodels/plan/search_view_model.dart
+++ b/lib/viewmodels/plan/search_view_model.dart
@@ -43,7 +43,10 @@ class SearchViewModel extends StateNotifier<List<Map<String, String>>> {
     List<Place> places;
 
     if (categoryCode == null) {
-      final spots = await _nearbyService.fetchSpots(loc: latLng);
+      final spots = await _nearbyService.fetchSpotsByCategory(
+      loc: latLng,
+      categoryCode: 'AT4',
+    );
       final foods = await _nearbyService.fetchFoods(loc: latLng);
       places = [...spots, ...foods];
     } else {

--- a/lib/views/home/recommended_place/widgets/hashtag_selector.dart
+++ b/lib/views/home/recommended_place/widgets/hashtag_selector.dart
@@ -1,7 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
 
-final hashtags = ['#전체', '#힐링', '#유적지', '#쇼핑', '#가족과 함께'];
+final hashtags = [
+  '#전체',
+  '#카페',
+  '#가볼만한 곳',
+  '#힐링',
+  '#유적지',
+  '#쇼핑',
+  '#가족과 함께',
+];
 
 class HashtagSelector extends StatelessWidget {
   const HashtagSelector({

--- a/lib/views/home/widgets/recommended_places_list.dart
+++ b/lib/views/home/widgets/recommended_places_list.dart
@@ -22,7 +22,12 @@ class RecommendedPlacesList extends ConsumerWidget {
       children: [
         HashtagSelector(
           selectedTag: selectedTag,
-          onTagTap: (tag) => selectedTagNotifier.state = tag,
+          onTagTap: (tag) async{
+            selectedTagNotifier.state = tag;
+            if (tag != null) {
+              await viewModel.reloadWithTag(tag);
+            }
+          },
         ),
         homeAsync.when(
           loading:
@@ -33,7 +38,9 @@ class RecommendedPlacesList extends ConsumerWidget {
           error:
               (_, __) => const SizedBox(
                 height: 170,
-                child: Center(child: Text('일시적인 문제로 추천을 불러오지 못했어요\n잠시 후 다시 시도해 주세요.')),
+                child: Center(
+                  child: Text('일시적인 문제로 추천을 불러오지 못했어요\n잠시 후 다시 시도해 주세요.'),
+                ),
               ),
           data: (state) {
             final spots = viewModel.getFilteredSpots(state.spots, selectedTag);

--- a/lib/views/plan/plan/place_search/place_search_page.dart
+++ b/lib/views/plan/plan/place_search/place_search_page.dart
@@ -2,8 +2,10 @@ import 'package:flutter/material.dart' hide SearchBar;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/core/widgets/bottom_bar.dart';
 import 'package:travel_muse_app/providers/plan/schedule/search_provider.dart';
+import 'package:travel_muse_app/providers/plan/schedule/selected_category_provider.dart';
 import 'package:travel_muse_app/providers/plan/schedule/selected_index_provider.dart';
 import 'package:travel_muse_app/services/plan/place_search_service.dart';
+import 'package:travel_muse_app/views/plan/plan/place_search/widgets/category_filter_chip.dart';
 import 'package:travel_muse_app/views/plan/plan/place_search/widgets/confirm_add_button.dart';
 import 'package:travel_muse_app/views/plan/plan/place_search/widgets/recent_search_section.dart';
 import 'package:travel_muse_app/views/plan/plan/place_search/widgets/region_recommend_header.dart';
@@ -65,6 +67,15 @@ class _PlaceSearchPageState extends ConsumerState<PlaceSearchPage> {
   Widget build(BuildContext context) {
     final searchResults = ref.watch(searchViewModelProvider);
     final selectedIndexes = ref.watch(selectedIndexProvider);
+    final selectedCategory = ref.watch(selectedCategoryProvider);
+    final categories = ['전체', '자연', '카페', '맛집', '가볼만한 곳'];
+    final categoryCodeMap = {
+      '전체': null,
+      '자연': 'AT4',
+      '카페': 'CE7',
+      '맛집': 'FD6',
+      '액티비티': 'CT1',
+    };
 
     return Scaffold(
       resizeToAvoidBottomInset: true,
@@ -83,8 +94,7 @@ class _PlaceSearchPageState extends ConsumerState<PlaceSearchPage> {
               padding: const EdgeInsets.all(16),
               child: SearchBar(
                 controller: _searchController,
-                onSearch:
-                    () => _handleSearch(_searchController.text), 
+                onSearch: () => _handleSearch(_searchController.text),
                 onQueryChanged: _handleSearch,
               ),
             ),
@@ -94,27 +104,70 @@ class _PlaceSearchPageState extends ConsumerState<PlaceSearchPage> {
                 _handleSearch(word);
               },
             ),
-            if (_showInitialMessage)
+            if (_showInitialMessage) ...[
               RegionRecommendHeader(region: widget.region),
-            const SizedBox(height: 8),
+
+              const SizedBox(height: 8),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.horizontal,
+                  child: Row(
+                    children:
+                        categories.map((category) {
+                          final isSelected = selectedCategory == category;
+
+                          return Padding(
+                            padding: const EdgeInsets.only(right: 8),
+                            child: CategoryFilterChip(
+                              label: category,
+                              selected: isSelected,
+                              onTap: () async {
+                                ref
+                                    .read(selectedCategoryProvider.notifier)
+                                    .state = category;
+
+                                final kakaoCode = categoryCodeMap[category];
+                                await ref
+                                    .read(searchViewModelProvider.notifier)
+                                    .loadRecommendedByRegion(
+                                      widget.region,
+                                      kakaoCode,
+                                    );
+                              },
+                            ),
+                          );
+                        }).toList(),
+                  ),
+                ),
+              ),
+
+              const SizedBox(height: 8),
+            ],
             Expanded(
-  child: searchResults.isEmpty
-      ? Center(
-          child: Text(
-            _showInitialMessage
-                ? '일시적인 문제로 추천을 불러오지 못했어요\n잠시 후 다시 시도해 주세요.'
-                : '검색 결과가 없습니다.',
-            textAlign: TextAlign.center,
-            style: const TextStyle(fontSize: 14, color: Colors.grey),
-          ),
-        )
-      : SearchResultList(
-          places: searchResults,
-          selectedIndexes: selectedIndexes,
-          onToggle: (i) =>
-              ref.read(selectedIndexProvider.notifier).toggle(i),
-        ),
-),
+              child:
+                  searchResults.isEmpty
+                      ? Center(
+                        child: Text(
+                          _showInitialMessage
+                              ? '일시적인 문제로 추천을 불러오지 못했어요\n잠시 후 다시 시도해 주세요.'
+                              : '검색 결과가 없습니다.',
+                          textAlign: TextAlign.center,
+                          style: const TextStyle(
+                            fontSize: 14,
+                            color: Colors.grey,
+                          ),
+                        ),
+                      )
+                      : SearchResultList(
+                        places: searchResults,
+                        selectedIndexes: selectedIndexes,
+                        onToggle:
+                            (i) => ref
+                                .read(selectedIndexProvider.notifier)
+                                .toggle(i),
+                      ),
+            ),
           ],
         ),
       ),

--- a/lib/views/plan/plan/place_search/widgets/category_filter_chip.dart
+++ b/lib/views/plan/plan/place_search/widgets/category_filter_chip.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class CategoryFilterChip extends StatelessWidget {
+  const CategoryFilterChip({
+    super.key,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return ChoiceChip(
+      label: Text(
+        label,
+        style: const TextStyle(
+          color: Colors.black,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+      selected: selected,
+      backgroundColor: Colors.white,
+      selectedColor: Colors.grey.shade100,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: BorderSide(color: Colors.grey.shade400, width: 1),
+      ),
+      onSelected: (_) => onTap(),
+    );
+  }
+}


### PR DESCRIPTION
### 🚀: 개요
- 검색페이지 명소 필터 기능 추가
- 홈화면 필터 카테고리 추가
### 🚀: 작업 내용
- 명소 필터링 기능 개선
- 카테고리 코드 기반 필터링 추가
- 태그 기반 분기 처리: 코드 기반과 키워드 기반을 나누어 필터링
- categoryCodeMap, tagKeywordMap 구조로 관리

### 📸: 실행 화면
<img width="400" height="867" alt="simulator_screenshot_9B3B1E15-2A3E-42B8-9BA1-C3596CBBEC5C" src="https://github.com/user-attachments/assets/2aafdd1f-a673-46b6-a120-1f9c0da0760a" />
<img width="400" height="867" alt="simulator_screenshot_84E083DD-498D-49F9-AE8F-FFEC680FC285" src="https://github.com/user-attachments/assets/dc24c84a-d331-4f51-9d3a-0a924f74ff7d" />

### 🚀: 조정 파일
- home_place
- home_state
- nearby_place_service
- home_view_model
- search_view_model
- place
- place_search_page
- selected_category_provider 추가
- category_filter_chip 추가


### 개발 결과
- 검색페이지 + 홈페이지 태그 클릭 시 필터 정상 작동
 - #카페, #가볼만한 곳은 categoryCode 기반 검색 
 - #힐링, #유적지 등은 기존 추천 명소에서 키워드 기반 필터 
 - 로딩 시 뷰 전체 재로드 현상 수정
 - state.spots 상태 보존하며 재사용

### issue
Closes #305 
