### PR TITLE
[Plan]일정 저장 후 네비게이터 설정 및 액션 추가

### DIFF
--- a/lib/views/plan/plan/schedule/schedule_page.dart
+++ b/lib/views/plan/plan/schedule/schedule_page.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
-import 'package:travel_muse_app/core/bottom_nav_bar_provider.dart';
 import 'package:travel_muse_app/core/widgets/custom_toast.dart';
 import 'package:travel_muse_app/models/home/home_place.dart';
 import 'package:travel_muse_app/models/plan/plans.dart';
 import 'package:travel_muse_app/providers/plan/schedule/schedule_provider.dart';
 import 'package:travel_muse_app/utills/date_utils.dart';
+import 'package:travel_muse_app/views/my_page/plan_list_page.dart';
 import 'package:travel_muse_app/views/plan/plan/place_search/place_search_page.dart';
 import 'package:travel_muse_app/views/plan/plan/schedule/widgets/ai_button.dart';
 import 'package:travel_muse_app/views/plan/plan/schedule/widgets/day_schedule_list.dart';
@@ -205,8 +205,10 @@ class _SchedulePageState extends ConsumerState<SchedulePage> {
                   message: '일정이 저장되었습니다.',
                   duration: const Duration(seconds: 2),
                 );
-                ref.read(bottomNavBarProvider.notifier).state = 0;
-                Navigator.popUntil(context, (route) => route.isFirst);
+                await Navigator.pushReplacement(
+                  context,
+                  MaterialPageRoute(builder: (_) => const PlanListPage()),
+                );
               },
             ),
           ],


### PR DESCRIPTION
### 🚀: 개요
- 일정 저장 후 네비게이터 설정 및 액션 추가

### 🚀: 작업 내용
- 일정 저장 후 네비게이터 설정 및 액션 추가

### 📸: 실행 화면
### 📸: 실행 화면

### 🚀: 조정 파일
- schedule_page.dart

### 개발 결과
- 일정 저장 후 네비게이터 설정 및 액션 추가

### issue
Closes #297 
