### PR TITLE
[Plan] 여행 일정 목록 텍스트 변경 및 등록 버튼 추가

### DIFF
--- a/lib/views/home/widgets/travel_register_button.dart
+++ b/lib/views/home/widgets/travel_register_button.dart
@@ -40,7 +40,7 @@ class TravelRegisterButton extends StatelessWidget {
                     Align(
                       alignment: Alignment.topRight,
                       child: Text(
-                        '여행 일정\n변경',
+                        '여행 일정\n목록',
                         textAlign: TextAlign.right,
                         style: TextStyle(
                           fontSize: 22,

--- a/lib/views/my_page/plan_list_page.dart
+++ b/lib/views/my_page/plan_list_page.dart
@@ -10,6 +10,7 @@ import 'package:travel_muse_app/utills/format_region.dart';
 import 'package:travel_muse_app/viewmodels/plan/schedule_view_model.dart';
 import 'package:travel_muse_app/views/my_page/widgets/confirm_dialog.dart';
 import 'package:travel_muse_app/views/my_page/widgets/my_page_list_item.dart';
+import 'package:travel_muse_app/views/plan/plan/calendar/calendar_page.dart';
 import 'package:travel_muse_app/views/plan/plan/schedule/schedule_page.dart';
 import 'package:travel_muse_app/views/widgets/custom_back_button.dart';
 
@@ -117,6 +118,17 @@ class _PlanListPageState extends ConsumerState<PlanListPage> {
                     );
                   },
                 ),
+      ),
+
+      floatingActionButton: FloatingActionButton(
+        backgroundColor: AppColors.primary[400],
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(builder: (context) => const CalendarPage()),
+          );
+        },
+        child: const Icon(Icons.add, color: AppColors.white),
       ),
     );
   }


### PR DESCRIPTION
### 🚀: 개요
- 여행 일정 목록 텍스트 변경 및 등록 버튼 추가

### 🚀: 작업 내용
- 여행 일정 목록 텍스트 변경
- 등록 버튼 추가

### 📸: 실행 화면
### 📸: 실행 화면

### 🚀: 조정 파일
- home_page.dart
- plan_list_page.dart

### 개발 결과
- 여행 일정 목록 텍스트 변경
- 등록 버튼 추가


### issue
Closes #316 
