### PR TITLE
[Etc] UT 반영 코드 리팩토링

### DIFF
--- a/lib/views/my_page/widgets/my_page_list_item.dart
+++ b/lib/views/my_page/widgets/my_page_list_item.dart
@@ -42,7 +42,7 @@ class MyPageListItem extends StatelessWidget {
                 ),
               ),
             ),
-            Icon(Icons.arrow_forward_ios, size: 16, color: AppColors.grey[600]),
+            Icon(Icons.arrow_forward_ios, size: 16, color: AppColors.grey[500]),
           ],
         ),
       ),

--- a/lib/views/my_page/widgets/my_page_menu.dart
+++ b/lib/views/my_page/widgets/my_page_menu.dart
@@ -103,7 +103,7 @@ class MyPageMenu extends StatelessWidget {
                 height: 1.50,
               ),
             ),
-            Icon(Icons.arrow_forward_ios, size: 16, color: AppColors.grey[600]),
+            Icon(Icons.arrow_forward_ios, size: 16, color: AppColors.grey[500]),
           ],
         ),
       ),

--- a/lib/views/post/widgets/list/post_item.dart
+++ b/lib/views/post/widgets/list/post_item.dart
@@ -37,9 +37,15 @@ class PostItem extends StatelessWidget {
               children: [
                 TimeAgoText(createdAt: post.createAt),
                 SizedBox(width: 8),
-                Text('댓글 ${post.commentCount}', style: AppTextStyles.postListContent),
+                Text(
+                  '댓글 ${post.commentCount}',
+                  style: AppTextStyles.postListContent,
+                ),
                 SizedBox(width: 8),
-                Text('조회 ${post.viewCount}', style: AppTextStyles.postListContent),
+                Text(
+                  '조회 ${post.viewCount}',
+                  style: AppTextStyles.postListContent,
+                ),
               ],
             ),
           ],
@@ -56,15 +62,19 @@ class PostItem extends StatelessWidget {
                     child: Image.network(post.thumbnail!, fit: BoxFit.cover),
                   ),
                 ),
-                Container(
-                  width: 23,
-                  height: 23,
-                  clipBehavior: Clip.antiAlias,
-                  decoration: AppOtherStyles.imageCountContainer,
-                  child: Center(
-                    child: Text('${post.images.length}', style: AppTextStyles.imageCount),
+                if (post.images.length > 1)
+                  Container(
+                    width: 23,
+                    height: 23,
+                    clipBehavior: Clip.antiAlias,
+                    decoration: AppOtherStyles.imageCountContainer,
+                    child: Center(
+                      child: Text(
+                        '${post.images.length}',
+                        style: AppTextStyles.imageCount,
+                      ),
+                    ),
                   ),
-                ),
               ],
             )
             : SizedBox.shrink(),

--- a/lib/views/post/widgets/list/post_list_view.dart
+++ b/lib/views/post/widgets/list/post_list_view.dart
@@ -1,3 +1,4 @@
+import 'package:custom_refresh_indicator/custom_refresh_indicator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:travel_muse_app/constants/app_colors.dart';
@@ -6,6 +7,7 @@ import 'package:travel_muse_app/providers/post/post_list_view_model_provider.dar
 import 'package:travel_muse_app/utills/throttler.dart';
 import 'package:travel_muse_app/views/post/widgets/list/post_item.dart';
 import 'package:travel_muse_app/views/post/widgets/list/post_loading_item.dart';
+import 'package:travel_muse_app/views/widgets/custom_circular_indicator.dart';
 
 class PostListView extends ConsumerStatefulWidget {
   const PostListView({super.key, required this.keyword, this.onPostUpdated});
@@ -69,10 +71,22 @@ class _PostListViewState extends ConsumerState<PostListView> {
               }
               return false;
             },
-            child: RefreshIndicator(
+            child: CustomRefreshIndicator(
               onRefresh: () async {
                 _refreshThrottler.run();
                 return Future.value();
+              },
+              builder: (context, child, controller) {
+                return Stack(
+                  alignment: Alignment.topCenter,
+                  children: [
+                    child,
+                    if (controller.isDragging ||
+                        controller.isArmed ||
+                        controller.isLoading)
+                      Positioned(top: 16, child: CustomCircularIndicator()),
+                  ],
+                );
               },
               child: ListView.builder(
                 itemCount: filteredPosts.length,
@@ -85,17 +99,14 @@ class _PostListViewState extends ConsumerState<PostListView> {
                         final result = await Navigator.of(
                           context,
                         ).pushNamed('/post_detail', arguments: post);
-                        // result가 Post면 리스트 반영
                         if (result is Post) {
                           ref
                               .read(postListViewModelProvider.notifier)
                               .updatePost(result);
                         }
-
                         if (result == true) {
                           ref.invalidate(postListViewModelProvider);
                         }
-
                         widget.onPostUpdated?.call();
                       },
                       child: Container(

--- a/lib/views/widgets/custom_circular_indicator.dart
+++ b/lib/views/widgets/custom_circular_indicator.dart
@@ -1,0 +1,70 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+class CustomCircularIndicator extends StatefulWidget {
+  const CustomCircularIndicator({super.key});
+
+  @override
+  State<CustomCircularIndicator> createState() =>
+      _CustomCircularIndicatorState();
+}
+
+class _CustomCircularIndicatorState extends State<CustomCircularIndicator>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(seconds: 2),
+      vsync: this,
+    )..repeat(); // 계속 회전
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RotationTransition(
+      turns: _controller,
+      child: ShaderMask(
+        shaderCallback: (bounds) {
+          return const LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomLeft,
+            colors: [Color(0xFF1164E3), Color(0x00FFFFFF)],
+            stops: [0.0, 1.0],
+          ).createShader(bounds);
+        },
+        blendMode: BlendMode.srcIn,
+        child: CustomPaint(size: const Size(54, 54), painter: _ArcPainter()),
+      ),
+    );
+  }
+}
+
+class _ArcPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rect = Offset.zero & size;
+    final startAngle = -pi / 2;
+    final sweepAngle = 4 * pi / 3;
+
+    final paint =
+        Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = 6
+          ..strokeCap = StrokeCap.round;
+
+    canvas.drawArc(rect.deflate(10), startAngle, sweepAngle, false, paint);
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) => false;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -145,6 +145,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  custom_refresh_indicator:
+    dependency: "direct main"
+    description:
+      name: custom_refresh_indicator
+      sha256: c34dd1dfb1f6b9ee2db9c5972586dba5e4445d79f8431f6ab098a6e963ccd39c
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.1"
   dbus:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   flutter_markdown: ^0.7.7+1
   drag_and_drop_lists: ^0.4.2
   logger: ^2.0.2
+  custom_refresh_indicator: ^4.0.1
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
### 🚀: 개요
- UT 반영 코드 리팩토링

### 🚀: 작업 내용
- 마이페이지 피그마 일치화
- 커뮤니티 탭에서 포스트 이미지 1개일 시 이미지 개수 미표시
- 커뮤니티 탭에서 새로고침 시 뜨는 컴포넌트 교체

### 📸: 실행 화면
<img width="300" height="640" alt="Simulator Screenshot - iPhone 16 - 2025-08-06 at 12 59 04" src="https://github.com/user-attachments/assets/ff20fc6e-a068-4100-be0f-f7d58bc92adc" />
<img width="300" height="640" alt="Simulator Screenshot - iPhone 16 - 2025-08-06 at 13 00 30" src="https://github.com/user-attachments/assets/2e70d104-4d52-458a-b88e-86ce1ab832e6" />


### 🚀: 조정 파일
- lib/views/my_page/widgets/my_page_list_item.dart
- lib/views/my_page/widgets/my_page_menu.dart
- lib/views/post/widgets/list/post_item.dart
- lib/views/post/widgets/list/post_list_view.dart
- lib/views/widgets/custom_circular_indicator.dart

### 개발 결과
- 마이페이지 chevron 아이콘 색상 변경
- 커뮤니티 탭 포스트 리스트에서, 포스트 이미지 복수일 때만 이미지 개수 표시
- 포스트 리스트 새로고침 리팩토링
- 포스트 리스트 새로고침 로딩 컴포넌트 구현 및 교체

### issue
Closes #334
